### PR TITLE
Remove exposed email addresses from documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ ChittyMCP supports complex multi-tool workflows called "chains" defined in `conf
 
 **Google Drive**
 - Evidence source monitoring
-- Path: `/Users/nb/Library/CloudStorage/GoogleDrive-nichobianchi@gmail.com/Shared drives/Arias V Bianchi`
+- Path: `/Users/nb/Library/CloudStorage/GoogleDrive-<USER_EMAIL>/Shared drives/Arias V Bianchi`
 
 **Cloudflare Workers**
 - Deployment target: `chittymcp.chittycorp-llc.workers.dev`

--- a/create-mcp-portal.sh
+++ b/create-mcp-portal.sh
@@ -30,7 +30,7 @@ BASE_URL="https://api.cloudflare.com/client/v4"
 # Configuration
 PORTAL_NAME="ChittyMCP Unified Portal"
 PORTAL_DOMAIN="mcp.chitty.cc"  # Change if needed
-USER_EMAIL="${USER_EMAIL:-nick@chittycorp.com}"
+USER_EMAIL="${USER_EMAIL:-<USER_EMAIL>}"
 
 echo -e "${GREEN}Creating Cloudflare MCP Portal...${NC}"
 echo "Account: $ACCOUNT_ID"

--- a/mcp-evidence-server/CLAUDE.md
+++ b/mcp-evidence-server/CLAUDE.md
@@ -163,7 +163,7 @@ Start real-time monitoring of a directory for new evidence files.
 **Example**:
 ```javascript
 await start_intake_monitoring({
-  sourceDir: "/Users/nb/Library/CloudStorage/GoogleDrive-nichobianchi@gmail.com/Shared drives/Arias V Bianchi"
+  sourceDir: "/Users/nb/Library/CloudStorage/GoogleDrive-<USER_EMAIL>/Shared drives/Arias V Bianchi"
 });
 ```
 

--- a/provision-via-mcp.md
+++ b/provision-via-mcp.md
@@ -90,7 +90,7 @@ Arguments:
   "decision": "allow",
   "include": [{
     "email": {
-      "email": "nick@chittycorp.com"
+      "email": "<USER_EMAIL>"
     }
   }],
   "precedence": 2


### PR DESCRIPTION
Replace hardcoded emails with <USER_EMAIL> placeholder for privacy.

Changed files:
- CLAUDE.md
- mcp-evidence-server/CLAUDE.md
- provision-via-mcp.md
- create-mcp-portal.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)