### PR TITLE
fix: point governance-gates to canonical reusable workflow

### DIFF
--- a/.github/workflows/governance-gates.yml
+++ b/.github/workflows/governance-gates.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   gates:
-    uses: ./.github/workflows/reusable-governance-gates.yml
+    uses: CHITTYOS/chittycommand/.github/workflows/reusable-governance-gates.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Fixes the hollow-compliance stub pattern documented in chittyos/chittycommand#87. This repo's `governance-gates.yml` references a local `./.github/workflows/reusable-governance-gates.yml` that does not exist, so `Governance Gates` has never actually run on main (`gh run list -R chittyos/chittymcp --branch main --workflow "Governance Gates"` → zero runs).
- Switches to the canonical centralized workflow at `CHITTYOS/chittycommand/.github/workflows/reusable-governance-gates.yml@main`.
- Follows the pattern validated in chittyos/chittyapi#54.

## Heads up
Since this causes `Governance Gates` to actually run for the first time, it may expose pre-existing hollow-compliance violations (e.g. secret allowlist gaps) that were previously silent. Any such failures will be derivatives of this fix exposing real policy issues, not regressions. They can be addressed in follow-up commits on this PR or separate PRs depending on scope.

Refs: chittyos/chittycommand#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)