### PR TITLE
fix(ci): point deploy workflow at root wrangler.jsonc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: mcp-unified-consolidated/package-lock.json
+          cache-dependency-path: package-lock.json
 
-      - name: Install dependencies (unified server)
-        working-directory: mcp-unified-consolidated
+      - name: Install dependencies (root)
         run: npm ci
 
       - name: Install dependencies (mcp-exec)
@@ -53,13 +52,15 @@ jobs:
             echo "⚠️  ChittyCheck not installed, skipping validation"
           fi
 
-      - name: Validate service bindings
+      - name: Validate wrangler config
         run: |
-          if [ ! -f "wrangler.toml" ]; then
-            echo "❌ wrangler.toml not found"
+          # Active deploy target is wrangler.jsonc at repo root (chittymcp aggregator);
+          # legacy wrangler.toml points at moved mcp-unified-consolidated.
+          if [ ! -f "wrangler.jsonc" ]; then
+            echo "❌ wrangler.jsonc not found at repo root"
             exit 1
           fi
-          echo "✓ wrangler.toml found"
+          echo "✓ wrangler.jsonc found"
 
       - name: Validate chains.json
         run: |
@@ -82,10 +83,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: mcp-unified-consolidated/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        working-directory: mcp-unified-consolidated
         run: npm ci
 
       - name: Deploy to Cloudflare Workers
@@ -93,7 +93,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler deploy --env production
+          npx wrangler deploy --config wrangler.jsonc
 
       - name: Verify deployment
         env:
@@ -168,10 +168,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: mcp-unified-consolidated/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        working-directory: mcp-unified-consolidated
         run: npm ci
 
       - name: Deploy to Cloudflare Workers (Staging)
@@ -179,7 +178,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npx wrangler deploy --env staging
+          npx wrangler deploy --config wrangler.jsonc
 
       - name: Verify staging deployment
         run: |


### PR DESCRIPTION
## Summary
Unblocks chittymcp deploys. The workflow was wired to `mcp-unified-consolidated/` which was relocated to `legacy-backup/` — the active deploy target is the root `wrangler.jsonc` (the new MCP aggregator at mcp.chitty.cc).

## Why
PR #47 merged successfully but the post-merge deploy failed at the cache step:
> `Some specified paths were not resolved, unable to cache dependencies.`
`mcp-unified-consolidated/package-lock.json` no longer exists at root. Production has been frozen on a stale Worker since the relocation.

## Changes
- `cache-dependency-path` → root `package-lock.json`
- Drop `working-directory: mcp-unified-consolidated` everywhere
- `npm ci` runs from repo root
- Validation step looks for `wrangler.jsonc` (was `wrangler.toml`)
- `wrangler deploy --config wrangler.jsonc` (was `--env production` — wrangler.jsonc has no named envs)

## Test plan
- [x] Cache path resolves (root package-lock.json exists)
- [ ] Workflow run completes `Validate ChittyMCP Service` job on this PR
- [ ] On merge, `Deploy to Production` job ships and `mcp.chitty.cc/health` returns 200