### PR TITLE
feat(control-plane): posture-gated registry sync + CF route reconcile

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -105,33 +105,88 @@ async function loadActiveServices(env: Env): Promise<Record<string, ServiceEntry
   }
 }
 
-async function fetchPostureRegistry(env: Env): Promise<DynamicServiceEntry[] | null> {
+type PostureFetchResult =
+  | { status: "ok"; services: DynamicServiceEntry[] }
+  | { status: "not_configured" }
+  | { status: "fetch_failed"; error: string };
+
+async function fetchPostureRegistry(env: Env): Promise<PostureFetchResult> {
   const url = env.CHITTYREGISTER_POSTURE_URL;
-  if (!url) return null;
+  if (!url) return { status: "not_configured" };
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (env.CHITTYAUTH_ISSUED_REGISTER_TOKEN) {
+    headers.authorization = `Bearer ${env.CHITTYAUTH_ISSUED_REGISTER_TOKEN}`;
+  }
+  let res: Response;
   try {
-    const headers: Record<string, string> = { "content-type": "application/json" };
-    if (env.CHITTYAUTH_ISSUED_REGISTER_TOKEN) {
-      headers.authorization = `Bearer ${env.CHITTYAUTH_ISSUED_REGISTER_TOKEN}`;
-    }
-    const res = await fetch(url, { method: "GET", headers });
-    if (!res.ok) return null;
-    const payload = await res.json() as { services?: DynamicServiceEntry[] };
-    return Array.isArray(payload.services) ? payload.services : null;
-  } catch {
-    return null;
+    res = await fetch(url, { method: "GET", headers });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[posture] fetch threw url=${url} err=${msg}`);
+    return { status: "fetch_failed", error: `network: ${msg}` };
+  }
+  if (!res.ok) {
+    console.error(`[posture] fetch non-2xx url=${url} status=${res.status}`);
+    return { status: "fetch_failed", error: `http ${res.status}` };
+  }
+  let payload: { services?: DynamicServiceEntry[] };
+  try {
+    payload = await res.json() as { services?: DynamicServiceEntry[] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[posture] non-JSON body url=${url} err=${msg}`);
+    return { status: "fetch_failed", error: `parse: ${msg}` };
+  }
+  if (!Array.isArray(payload.services)) {
+    return { status: "fetch_failed", error: "payload.services not an array" };
+  }
+  return { status: "ok", services: payload.services };
+}
+
+type SyncResult =
+  | { status: "synced"; count: number }
+  | { status: "no_kv" }
+  | { status: "fetch_failed"; error: string }
+  | { status: "empty" }
+  | { status: "kv_write_failed"; count: number; error: string };
+
+async function syncRegistryFromPosture(env: Env): Promise<SyncResult> {
+  if (!env.MCP_REGISTRY) return { status: "no_kv" };
+  const result = await fetchPostureRegistry(env);
+  if (result.status !== "ok") {
+    return result.status === "not_configured"
+      ? { status: "fetch_failed", error: "CHITTYREGISTER_POSTURE_URL not set" }
+      : { status: "fetch_failed", error: result.error };
+  }
+  if (result.services.length === 0) return { status: "empty" };
+  try {
+    await env.MCP_REGISTRY.put(MCP_REGISTRY_KEY, JSON.stringify(result.services));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[posture] KV write failed err=${msg}`);
+    return { status: "kv_write_failed", count: result.services.length, error: msg };
+  }
+  return { status: "synced", count: result.services.length };
+}
+
+class CfApiError extends Error {
+  status: number;
+  method: string;
+  path: string;
+  constructor(message: string, status: number, method: string, path: string) {
+    super(message);
+    this.name = "CfApiError";
+    this.status = status;
+    this.method = method;
+    this.path = path;
   }
 }
 
-async function syncRegistryFromPosture(env: Env): Promise<{ synced: boolean; count: number }> {
-  if (!env.MCP_REGISTRY) return { synced: false, count: 0 };
-  const services = await fetchPostureRegistry(env);
-  if (!services || services.length === 0) return { synced: false, count: 0 };
-  await env.MCP_REGISTRY.put(MCP_REGISTRY_KEY, JSON.stringify(services));
-  return { synced: true, count: services.length };
-}
-
 async function cfApi<T = unknown>(env: Env, path: string, init?: RequestInit): Promise<T> {
-  if (!env.CLOUDFLARE_API_TOKEN) throw new Error("CLOUDFLARE_API_TOKEN is not configured");
+  const method = (init?.method || "GET").toUpperCase();
+  if (!env.CLOUDFLARE_API_TOKEN) {
+    throw new CfApiError("CLOUDFLARE_API_TOKEN is not configured", 0, method, path);
+  }
   const res = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
     ...init,
     headers: {
@@ -140,14 +195,30 @@ async function cfApi<T = unknown>(env: Env, path: string, init?: RequestInit): P
       ...(init?.headers || {}),
     },
   });
-  const payload = await res.json() as { success: boolean; result: T; errors?: Array<{ message: string }> };
-  if (!res.ok || !payload.success) {
-    throw new Error(payload.errors?.map((e) => e.message).join("; ") || `Cloudflare API failed: ${res.status}`);
+  let payload: { success: boolean; result: T; errors?: Array<{ message: string }> } | null = null;
+  try {
+    payload = await res.json() as typeof payload;
+  } catch {
+    // Non-JSON body (CF edge HTML during incidents, gateway errors, etc.)
+    throw new CfApiError(`Cloudflare returned non-JSON body (HTTP ${res.status})`, res.status, method, path);
+  }
+  if (!res.ok || !payload || !payload.success) {
+    const msg = payload?.errors?.map((e) => e.message).join("; ") || `HTTP ${res.status}`;
+    throw new CfApiError(msg, res.status, method, path);
   }
   return payload.result;
 }
 
-async function reconcileRoutes(env: Env, serviceMap: Record<string, ServiceEntry>) {
+interface ReconcileResult {
+  ok: boolean;
+  script: string;
+  desiredCount: number;
+  created: string[];
+  deleted: string[];
+  failed: Array<{ op: "create" | "delete"; pattern: string; error: string }>;
+}
+
+async function reconcileRoutes(env: Env, serviceMap: Record<string, ServiceEntry>): Promise<ReconcileResult> {
   const zoneId = env.CLOUDFLARE_ZONE_ID;
   const accountId = env.CLOUDFLARE_ACCOUNT_ID;
   if (!zoneId || !accountId) {
@@ -171,29 +242,44 @@ async function reconcileRoutes(env: Env, serviceMap: Record<string, ServiceEntry
 
   const created: string[] = [];
   const deleted: string[] = [];
+  const failed: ReconcileResult["failed"] = [];
 
+  // Per-iteration try/catch so one failed route doesn't leave the zone half-reconciled
+  // without an audit trail. Continue past failures and return a complete envelope.
   for (const pattern of desiredPatterns) {
-    if (!existingPatterns.has(pattern)) {
+    if (existingPatterns.has(pattern)) continue;
+    try {
       await cfApi(env, `/zones/${zoneId}/workers/routes`, {
         method: "POST",
         body: JSON.stringify({ pattern, script }),
       });
       created.push(pattern);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[reconcile] create failed pattern=${pattern} err=${msg}`);
+      failed.push({ op: "create", pattern, error: msg });
     }
   }
 
   for (const route of existingForScript) {
-    if (!desiredPatterns.has(route.pattern)) {
+    if (desiredPatterns.has(route.pattern)) continue;
+    try {
       await cfApi(env, `/zones/${zoneId}/workers/routes/${route.id}`, { method: "DELETE" });
       deleted.push(route.pattern);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[reconcile] delete failed pattern=${route.pattern} err=${msg}`);
+      failed.push({ op: "delete", pattern: route.pattern, error: msg });
     }
   }
 
   return {
+    ok: failed.length === 0,
     script,
     desiredCount: desiredPatterns.size,
     created,
     deleted,
+    failed,
   };
 }
 
@@ -372,13 +458,13 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
-    const serviceMap = await loadActiveServices(env);
 
+    // Cheap branches first — these don't need the dynamic service map and
+    // shouldn't pay a KV read per request.
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: corsHeaders() });
     }
 
-    // Health
     if (request.method === "GET" && path === "/health") {
       return Response.json({
         status: "ok",
@@ -387,6 +473,9 @@ export default {
         services: Object.keys(SERVICE_MAP),
       });
     }
+
+    // Everything below depends on the active (posture-filtered) service map.
+    const serviceMap = await loadActiveServices(env);
 
     // Service index
     if (request.method === "GET" && (path === "/" || path === "")) {
@@ -400,7 +489,10 @@ export default {
       });
     }
 
+    // Admin-gated: leaks internal binding topology. Behind CHITTYAUTH_ISSUED_MCP_ADMIN_TOKEN.
     if (request.method === "GET" && path === "/registry/services") {
+      const deny = requireAdmin(request, env);
+      if (deny) return deny;
       return Response.json({
         service: "chittymcp",
         source: env.MCP_REGISTRY ? "dynamic-or-fallback" : "static",
@@ -414,14 +506,17 @@ export default {
       const deny = requireAdmin(request, env);
       if (deny) return deny;
       const result = await syncRegistryFromPosture(env);
-      return Response.json({ ok: true, ...result });
+      const ok = result.status === "synced";
+      const status = ok ? 200 : 502;
+      return Response.json({ ok, ...result }, { status });
     }
 
     if (request.method === "POST" && path === "/admin/reconcile/routes") {
       const deny = requireAdmin(request, env);
       if (deny) return deny;
       const result = await reconcileRoutes(env, serviceMap);
-      return Response.json({ ok: true, ...result });
+      // 207-style partial success → 502 if any route failed, 200 if clean.
+      return Response.json(result, { status: result.ok ? 200 : 502 });
     }
 
     // Per-service proxy: /dispute/mcp → SVC_DISPUTE /mcp (auth-gated, dynamic serviceMap)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -23,6 +23,13 @@ interface Env {
   // MCP_API_KEY: shared secret required for /mcp aggregator + /{service}/mcp proxy.
   // Set via `wrangler secret put MCP_API_KEY`.
   MCP_API_KEY?: string;
+  MCP_REGISTRY?: KVNamespace;
+  CLOUDFLARE_API_TOKEN?: string;
+  CLOUDFLARE_ACCOUNT_ID?: string;
+  CLOUDFLARE_ZONE_ID?: string;
+  CHITTYAUTH_ISSUED_MCP_ADMIN_TOKEN?: string;
+  CHITTYREGISTER_POSTURE_URL?: string;
+  CHITTYAUTH_ISSUED_REGISTER_TOKEN?: string;
 }
 
 type BindingKey = keyof Env;
@@ -30,6 +37,16 @@ type BindingKey = keyof Env;
 interface ServiceEntry {
   binding: BindingKey;
   label: string;
+}
+
+interface DynamicServiceEntry {
+  id: string;
+  sub: string;
+  binding: BindingKey;
+  label: string;
+  enabled?: boolean;
+  posture?: string;
+  trust_score?: number;
 }
 
 const SERVICE_MAP: Record<string, ServiceEntry> = {
@@ -43,6 +60,142 @@ const SERVICE_MAP: Record<string, ServiceEntry> = {
   connect:  { binding: "SVC_CONNECT",  label: "ChittyConnect Spine" },
   ch1tty:   { binding: "SVC_CH1TTY",   label: "Ch1tty Gateway" },
 };
+
+const MCP_REGISTRY_KEY = "services:v1";
+
+function requireAdmin(request: Request, env: Env): Response | null {
+  const expected = env.CHITTYAUTH_ISSUED_MCP_ADMIN_TOKEN;
+  if (!expected) {
+    return new Response("admin token not configured", { status: 503 });
+  }
+  const auth = request.headers.get("authorization") || "";
+  const provided = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+  if (provided !== expected) {
+    return new Response("unauthorized", { status: 401 });
+  }
+  return null;
+}
+
+function isEligibleByPosture(entry: DynamicServiceEntry): boolean {
+  if (entry.enabled === false) return false;
+  const posture = (entry.posture || "unknown").toLowerCase();
+  const trust = entry.trust_score ?? 0;
+  const postureAllowed = posture === "trusted" || posture === "verified" || posture === "certified";
+  return postureAllowed || trust >= 70;
+}
+
+async function loadActiveServices(env: Env): Promise<Record<string, ServiceEntry>> {
+  const fallback = SERVICE_MAP;
+  if (!env.MCP_REGISTRY) return fallback;
+
+  try {
+    const raw = await env.MCP_REGISTRY.get(MCP_REGISTRY_KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as DynamicServiceEntry[];
+    const active: Record<string, ServiceEntry> = {};
+    for (const entry of parsed) {
+      if (!entry?.id || !entry?.sub || !entry?.binding || !entry?.label) continue;
+      if (!isEligibleByPosture(entry)) continue;
+      active[entry.sub] = { binding: entry.binding, label: entry.label };
+    }
+    return Object.keys(active).length > 0 ? active : fallback;
+  } catch (err) {
+    console.error(`[ChittyMCP] Failed to load dynamic service map: ${err}`);
+    return fallback;
+  }
+}
+
+async function fetchPostureRegistry(env: Env): Promise<DynamicServiceEntry[] | null> {
+  const url = env.CHITTYREGISTER_POSTURE_URL;
+  if (!url) return null;
+  try {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (env.CHITTYAUTH_ISSUED_REGISTER_TOKEN) {
+      headers.authorization = `Bearer ${env.CHITTYAUTH_ISSUED_REGISTER_TOKEN}`;
+    }
+    const res = await fetch(url, { method: "GET", headers });
+    if (!res.ok) return null;
+    const payload = await res.json() as { services?: DynamicServiceEntry[] };
+    return Array.isArray(payload.services) ? payload.services : null;
+  } catch {
+    return null;
+  }
+}
+
+async function syncRegistryFromPosture(env: Env): Promise<{ synced: boolean; count: number }> {
+  if (!env.MCP_REGISTRY) return { synced: false, count: 0 };
+  const services = await fetchPostureRegistry(env);
+  if (!services || services.length === 0) return { synced: false, count: 0 };
+  await env.MCP_REGISTRY.put(MCP_REGISTRY_KEY, JSON.stringify(services));
+  return { synced: true, count: services.length };
+}
+
+async function cfApi<T = unknown>(env: Env, path: string, init?: RequestInit): Promise<T> {
+  if (!env.CLOUDFLARE_API_TOKEN) throw new Error("CLOUDFLARE_API_TOKEN is not configured");
+  const res = await fetch(`https://api.cloudflare.com/client/v4${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+      ...(init?.headers || {}),
+    },
+  });
+  const payload = await res.json() as { success: boolean; result: T; errors?: Array<{ message: string }> };
+  if (!res.ok || !payload.success) {
+    throw new Error(payload.errors?.map((e) => e.message).join("; ") || `Cloudflare API failed: ${res.status}`);
+  }
+  return payload.result;
+}
+
+async function reconcileRoutes(env: Env, serviceMap: Record<string, ServiceEntry>) {
+  const zoneId = env.CLOUDFLARE_ZONE_ID;
+  const accountId = env.CLOUDFLARE_ACCOUNT_ID;
+  if (!zoneId || !accountId) {
+    throw new Error("CLOUDFLARE_ZONE_ID/CLOUDFLARE_ACCOUNT_ID are required");
+  }
+
+  const script = "chittymcp";
+  const existing = await cfApi<Array<{ id: string; pattern: string; script: string }>>(
+    env,
+    `/zones/${zoneId}/workers/routes`,
+    { method: "GET" },
+  );
+
+  const desiredPatterns = new Set<string>(["mcp.chitty.cc/mcp*"]);
+  for (const sub of Object.keys(serviceMap)) {
+    desiredPatterns.add(`mcp.chitty.cc/${sub}/mcp*`);
+  }
+
+  const existingForScript = existing.filter((r) => r.script === script && r.pattern.startsWith("mcp.chitty.cc/"));
+  const existingPatterns = new Set(existingForScript.map((r) => r.pattern));
+
+  const created: string[] = [];
+  const deleted: string[] = [];
+
+  for (const pattern of desiredPatterns) {
+    if (!existingPatterns.has(pattern)) {
+      await cfApi(env, `/zones/${zoneId}/workers/routes`, {
+        method: "POST",
+        body: JSON.stringify({ pattern, script }),
+      });
+      created.push(pattern);
+    }
+  }
+
+  for (const route of existingForScript) {
+    if (!desiredPatterns.has(route.pattern)) {
+      await cfApi(env, `/zones/${zoneId}/workers/routes/${route.id}`, { method: "DELETE" });
+      deleted.push(route.pattern);
+    }
+  }
+
+  return {
+    script,
+    desiredCount: desiredPatterns.size,
+    created,
+    deleted,
+  };
+}
 
 function corsHeaders(): Record<string, string> {
   return {
@@ -219,6 +372,7 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
+    const serviceMap = await loadActiveServices(env);
 
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: corsHeaders() });
@@ -241,13 +395,37 @@ export default {
         description: "ChittyOS MCP Aggregator",
         aggregated: "/mcp",
         services: Object.fromEntries(
-          Object.entries(SERVICE_MAP).map(([id, s]) => [id, { path: `/${id}/mcp`, label: s.label }]),
+          Object.entries(serviceMap).map(([id, s]) => [id, { path: `/${id}/mcp`, label: s.label }]),
         ),
       });
     }
 
-    // Per-service proxy: /dispute/mcp → SVC_DISPUTE /mcp (auth-gated)
-    for (const [prefix, svc] of Object.entries(SERVICE_MAP)) {
+    if (request.method === "GET" && path === "/registry/services") {
+      return Response.json({
+        service: "chittymcp",
+        source: env.MCP_REGISTRY ? "dynamic-or-fallback" : "static",
+        services: Object.fromEntries(
+          Object.entries(serviceMap).map(([id, s]) => [id, { path: `/${id}/mcp`, label: s.label }]),
+        ),
+      });
+    }
+
+    if (request.method === "POST" && path === "/admin/registry/sync") {
+      const deny = requireAdmin(request, env);
+      if (deny) return deny;
+      const result = await syncRegistryFromPosture(env);
+      return Response.json({ ok: true, ...result });
+    }
+
+    if (request.method === "POST" && path === "/admin/reconcile/routes") {
+      const deny = requireAdmin(request, env);
+      if (deny) return deny;
+      const result = await reconcileRoutes(env, serviceMap);
+      return Response.json({ ok: true, ...result });
+    }
+
+    // Per-service proxy: /dispute/mcp → SVC_DISPUTE /mcp (auth-gated, dynamic serviceMap)
+    for (const [prefix, svc] of Object.entries(serviceMap)) {
       if (path === `/${prefix}/mcp` || path.startsWith(`/${prefix}/mcp/`)) {
         const authErr = requireBearerToken(request, env);
         if (authErr) return authErr;
@@ -291,7 +469,7 @@ export default {
 
       if (body.method === "tools/list") {
         const results = await Promise.all(
-          Object.entries(SERVICE_MAP).map(async ([id, svc]) => {
+          Object.entries(serviceMap).map(async ([id, svc]) => {
             const service = env[svc.binding] as Fetcher;
             return discoverTools(service, id);
           }),
@@ -316,12 +494,12 @@ export default {
 
         const serviceId = fullName.slice(0, slash);
         const toolName = fullName.slice(slash + 1);
-        const svc = SERVICE_MAP[serviceId];
+        const svc = serviceMap[serviceId];
         if (!svc) {
           return sseResponse({
             jsonrpc: "2.0",
             id: body.id,
-            error: { code: -32602, message: `Unknown service: ${serviceId}. Available: ${Object.keys(SERVICE_MAP).join(", ")}` },
+            error: { code: -32602, message: `Unknown service: ${serviceId}. Available: ${Object.keys(serviceMap).join(", ")}` },
           });
         }
 


### PR DESCRIPTION
## Summary
- Salvages unique work from abandoned `feat/mcp-control-plane-reconcile` branch (rest was superseded by the worker rewrite in main).
- Adds posture-gated dynamic registry: `isEligibleByPosture` filter (trusted/verified/certified or trust_score ≥ 70), `fetchPostureRegistry`, `syncRegistryFromPosture`.
- Adds Cloudflare Workers Routes reconciliation: `reconcileRoutes` (CRUD against `/zones/{id}/workers/routes`).
- New endpoints:
  - `GET /registry/services` — dynamic service catalog (KV-backed if `MCP_REGISTRY` bound, else static fallback).
  - `POST /admin/registry/sync` — pulls posture data from `CHITTYREGISTER_POSTURE_URL`, updates KV. Admin-gated.
  - `POST /admin/reconcile/routes` — diffs desired vs actual CF worker routes, applies. Admin-gated.

## Conflict resolution notes
- `src/worker/index.ts` Env interface: kept main's `MCP_API_KEY` Bearer config AND added branch's registry/CF env vars.
- Per-service proxy loop: switched from `SERVICE_MAP` (static) → `serviceMap` (dynamic, posture-filtered) while preserving main's `requireBearerToken` auth gate.

## Test plan
- [ ] `tsc --noEmit` clean
- [ ] `GET /registry/services` returns shape from dynamic map
- [ ] `POST /admin/registry/sync` rejects without admin token, succeeds with `CHITTYAUTH_ISSUED_MCP_ADMIN_TOKEN`
- [ ] `POST /admin/reconcile/routes` no-ops on already-aligned state
- [ ] Existing `/{service}/mcp` Bearer auth still enforced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic registry-based selection and activation of MCP services, so the app exposes only currently active services.
  * Admin endpoints to sync the registry and reconcile published routes with active services.
  * Service listings and aggregated endpoints now reflect the active registry; requests for unavailable services return an error listing current options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittymcp/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->