### PR TITLE
chore(chatgpt-gateway): add Deprecation/Sunset headers — retire to mcp.chitty.cc

### DIFF
--- a/mcp-gateway- chatgpt/src/index.js
+++ b/mcp-gateway- chatgpt/src/index.js
@@ -31,6 +31,17 @@ app.use('/*', cors({
 // Logging middleware
 app.use('/*', logger());
 
+// Deprecation headers — this gateway is being retired in favor of the canonical
+// mcp.chitty.cc aggregator. ChatGPT MCP clients should re-register against
+// https://mcp.chitty.cc/ (same OAuth flow, same scopes, same tools, unified
+// audit). Sunset window: 2026-08-15.
+app.use('/*', async (c, next) => {
+  c.header('Deprecation', 'true');
+  c.header('Sunset', 'Sat, 15 Aug 2026 00:00:00 GMT');
+  c.header('Link', '<https://mcp.chitty.cc/mcp>; rel="successor-version", <https://mcp.chitty.cc/sse>; rel="alternate"');
+  await next();
+});
+
 /**
  * Health check endpoint
  * GET /health


### PR DESCRIPTION
## Summary
Emit standard deprecation signals on the ChatGPT-specific MCP gateway. ChatGPT MCP doesn't require a unique hostname — the OpenAI spec only needs a valid OAuth issuer + MCP transport, both already on the canonical \`mcp.chitty.cc\` aggregator with broader scope coverage and unified audit.

## Headers added (every response)
\`\`\`
Deprecation: true
Sunset: Sat, 15 Aug 2026 00:00:00 GMT
Link: <https://mcp.chitty.cc/mcp>; rel="successor-version",
      <https://mcp.chitty.cc/sse>; rel="alternate"
\`\`\`

## Retirement plan
1. Merge + deploy this PR → ChatGPT clients see deprecation signals.
2. Add \`mcp.chitty.cc\` to ChatGPT Connector config; OAuth flow auto-registers via \`/register\`.
3. Watch traffic shift from \`mcp-chatgpt.chitty.cc\` → \`mcp.chitty.cc\`.
4. After 2026-08-15: delete CF route \`7de271ce55d64215b3d89f8e5c49309b\`, delete \`chittymcp-gateway\` worker, delete \`mcp-gateway- chatgpt/\` subtree.

## Companion PR
chittyos/chittyconnect#TBD also adds deprecation headers to \`connect.chitty.cc/chatgpt/mcp\` (same retirement target).

No tool/protocol behavior changes; pure response-header addition.