### PR TITLE
chore(aggregator): bind tasks, viewport, sandbox

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -44,6 +44,9 @@
     { "binding": "SVC_RESOLVE",      "service": "chittyagent-resolve" },
     { "binding": "SVC_SCRAPE",       "service": "chittyagent-scrape" },
     { "binding": "SVC_SHIP",         "service": "chittyagent-ship" },
-    { "binding": "SVC_STORAGE",      "service": "chittyagent-storage" }
+    { "binding": "SVC_STORAGE",      "service": "chittyagent-storage" },
+    { "binding": "SVC_TASKS",        "service": "chittyagent-tasks" },
+    { "binding": "SVC_VIEWPORT",     "service": "chittyagent-viewport" },
+    { "binding": "SVC_SANDBOX",      "service": "chittyagent-sandbox" }
   ]
 }


### PR DESCRIPTION
Adds SVC_TASKS, SVC_VIEWPORT, SVC_SANDBOX bindings. Aggregator deployed with 26 bindings. Pending: route these in worker's SERVICE_MAP (or via dynamic-registry KV).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service configurations to enable new internal service integrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittymcp/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->