### PR TITLE
fix(mcp): don't enforce aud on CF Access OAuth tokens — fixes Claude.ai 'Authorization failed'

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -351,9 +351,15 @@ async function verifyCfAccessJwt(token: string, env: Env): Promise<boolean> {
     if (!cfAccessJwks) {
       cfAccessJwks = createRemoteJWKSet(new URL("https://chittycorp.cloudflareaccess.com/cdn-cgi/access/certs"));
     }
-    const opts: { issuer: string; audience?: string } = { issuer: "https://chittycorp.cloudflareaccess.com" };
-    if (env.CF_ACCESS_AUD) opts.audience = env.CF_ACCESS_AUD;
-    await jwtVerify(token, cfAccessJwks, opts);
+    // Verify signature + issuer only. CF Access OAuth issues tokens whose
+    // `aud` claim is the DCR-registered client_id (e.g. Claude.ai's
+    // registration), NOT the mcp-type app's AUD. Enforcing CF_ACCESS_AUD
+    // here would falsely reject all OAuth-flow Bearer tokens from clients
+    // like Claude.ai's MCP connector. The mcp-type app's policy gate at
+    // CF Access already enforces app-level authorization upstream.
+    await jwtVerify(token, cfAccessJwks, { issuer: "https://chittycorp.cloudflareaccess.com" });
+    // CF_ACCESS_AUD intentionally NOT enforced — see comment above.
+    void env;
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Worker was rejecting legitimate Claude.ai OAuth tokens because their aud claim is the DCR client_id, not the mcp-type app's AUD. CF Access already gates app-level auth upstream; worker now verifies sig+iss only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudflare Access JWT verification now only validates token signature and issuer, removing audience claim enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chittyos/chittymcp/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->