### PR TITLE
feat(aggregator): bind chittyagent-ai (Cloudflare AI Gateway)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ mcp-diagnostics-*.html
 # Backups
 .backups/
 *.bak
+.tmp-oauth.mjs

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -11,6 +11,7 @@
  */
 
 interface Env {
+  SVC_AI: Fetcher;
   SVC_ALCHEMIST: Fetcher;
   SVC_AUTH: Fetcher;
   SVC_AUTOASSIST: Fetcher;
@@ -78,6 +79,7 @@ interface DynamicServiceEntry {
 }
 
 const SERVICE_MAP: Record<string, ServiceEntry> = {
+  ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)" },
   alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)" },
   auth:             { binding: "SVC_AUTH",             label: "ChittyAuth (identity + tokens)" },
   autoassist:       { binding: "SVC_AUTOASSIST",       label: "AutoAssist" },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,7 @@
   // Source of truth for membership: docs/agent-registry-triage.json (Bucket A).
   // Services not yet deployed (Bucket C) are intentionally NOT bound — re-add when live.
   "services": [
+    { "binding": "SVC_AI",           "service": "chittyagent-ai" },
     { "binding": "SVC_ALCHEMIST",    "service": "chittyagent-alchemist" },
     { "binding": "SVC_AUTH",         "service": "chittyagent-auth" },
     { "binding": "SVC_AUTOASSIST",   "service": "chittyagent-autoassist" },


### PR DESCRIPTION
Adds the new chittyagent-ai worker (ai.chitty.cc) to the chittymcp aggregator.

## Changes
- wrangler.jsonc: add SVC_AI → chittyagent-ai service binding
- src/worker/index.ts: add SVC_AI to Env and ai entry to SERVICE_MAP

## Verification
- Worker live at ai.chitty.cc/health, has_aig_token true
- MCP tools/list returns ai_complete + ai_list_models
- wrangler deploy --dry-run passes; SVC_AI binding recognised

## Upstream
Worker scaffold: CHITTYOS/chittyentity#447

## Follow-ups
- ch1tty/servers.json registration
- Streaming support in ai_complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the service routing system to integrate an AI gateway service, enabling the aggregator to discover and route requests to AI-powered services.
  * Updated service configuration and worker environment setup for the new AI service binding.
  * Updated version control to exclude temporary OAuth operation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->