### PR TITLE
feat(aggregator): ChittyCPA /cpa/mcp + real ChittyMsg /msg/mcp via category sub-views

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -17,24 +17,35 @@ federates them under a single canonical endpoint (`mcp.chitty.cc`) so any MCP cl
 
 CF Gateway is the registry of record. Three aggregators consume it:
 
-| Aggregator | Surface | Audience | Auth |
-|------------|---------|----------|------|
-| **chittymcp** (this repo) | All services / all tools | Machines, agents, devs | Service-binding / token |
-| **chittymsg** | Messaging-domain MCPs (quo, gmail, imsg, openphone, rmail, …) | Comms surfaces | Token |
-| **ch1tty** | Smart / AI gateway, curated subset | Humans, portal | OAuth |
+| Aggregator | Endpoint | Surface | Audience | Auth |
+|------------|----------|---------|----------|------|
+| **chittymcp** (this repo) | `/mcp` | All services / all tools | Machines, agents, devs | Service-binding / token |
+| **chittycpa** | `/cpa/mcp` | `category:finance` MCPs (finance; +future stripe/quickbooks/plaid) | Finance / accounting surfaces | Token |
+| **chittymsg** | `/msg/mcp` | `category:communication` MCPs (quo, twilio, imessage, bluebubbles, notes, dispute, autoassist) | Comms surfaces | Token |
+| **ch1tty** | (separate gateway) | Smart / AI gateway, curated subset | Humans, portal | OAuth |
 
-### Membership (hybrid: tags + per-aggregator policy)
+### Membership (category-based aggregate sub-views)
 
-Each CF-registered service MCP declares tags at registration time
-(`domain:messaging`, `audience:human`, `auth:oauth-ok`, `surface:all`, …).
-Each aggregator applies a policy filter over those tags:
+Each service entry in `SERVICE_MAP` (src/worker/index.ts) carries a `category`
+(`finance`, `communication`, `platform`, `infra`, `legal`, …), reusing the
+`category` vocabulary from ch1tty `servers.json`. A POST to `/{view}/mcp`
+federates only the services whose category matches the view's category, then
+runs the identical aggregate pipeline (initialize / tools/list / tools/call /
+prompts / resources) over that filtered set.
 
-- **chittymcp**: includes everything with `surface:all` (default for new services)
-- **chittymsg**: `domain:messaging`
-- **ch1tty**: `audience:human AND auth:oauth-ok`
+- **chittymcp** (`/mcp`): every bound service (no filter)
+- **chittycpa** (`/cpa/mcp`): `category === "finance"`
+- **chittymsg** (`/msg/mcp`): `category === "communication"`
 
-New services join their relevant aggregators automatically by declaring the right tags;
-aggregator-side policy can still reject (fail-closed).
+View → category mapping lives in `VIEW_CATEGORIES` (src/worker/index.ts). New
+services join a view automatically by declaring the matching `category`; an
+empty filtered set fails CLOSED (zero tools, not the full surface). View names
+never shadow a real service id — a service named like a view wins the route.
+
+> NOTE (2026-06): Prior versions of this charter described `domain:`/`surface:`
+> tag filters. Those were **documentation-only and never enforced** in the
+> worker. The category-based sub-views above are the real, implemented
+> mechanism that replaces them.
 
 ## Endpoint Convention
 

--- a/docs/agent-registry-triage.json
+++ b/docs/agent-registry-triage.json
@@ -28,9 +28,18 @@
     "tracking": "chittyentity commit d2cc353 (feat: canonicalize {name}.chitty.cc per user override)"
   },
   "policy_filters": {
-    "chittymcp":  "surface:all",
-    "chittymsg":  "domain:messaging",
-    "ch1tty":     "audience:human AND auth:oauth-ok"
+    "_note": "IMPLEMENTED as category-based aggregate sub-views in src/worker/index.ts (VIEW_CATEGORIES). The prior domain:/surface:/audience: tag filters were doc-only and never enforced. Each SERVICE_MAP entry carries a `category`; POST /{view}/mcp filters to that category and reuses the full aggregate pipeline.",
+    "chittymcp":  "* (no filter — all bound services)",
+    "chittycpa":  "category:finance",
+    "chittymsg":  "category:communication",
+    "ch1tty":     "(separate OAuth gateway, not a chittymcp sub-view)"
+  },
+  "aggregate_subviews": {
+    "endpoint_pattern": "https://mcp.chitty.cc/{view}/mcp",
+    "views": {
+      "cpa": { "category": "finance", "services": ["finance"], "note": "ChittyCPA — auto-includes future category:finance agents (stripe/quickbooks/plaid/mercury-worker)" },
+      "msg": { "category": "communication", "services": ["autoassist", "bluebubbles", "dispute", "imessage", "notes", "quo", "twilio"] }
+    }
   },
   "unmerged_branches_blocking_main": [],
   "next_actions": [

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -80,6 +80,12 @@ type BindingKey = keyof Env;
 interface ServiceEntry {
   binding: BindingKey;
   label: string;
+  // Membership category for aggregate sub-views (e.g. /cpa/mcp = finance,
+  // /msg/mcp = communication). Reuses the `category` vocabulary from
+  // ch1tty servers.json (finance, communication, platform, …) — NOT the
+  // CHARTER's `domain:` tag, which was only ever documented, never enforced.
+  // Defaults to "platform" when a dynamic entry omits it.
+  category: string;
 }
 
 interface DynamicServiceEntry {
@@ -87,43 +93,54 @@ interface DynamicServiceEntry {
   sub: string;
   binding: BindingKey;
   label: string;
+  category?: string;
   enabled?: boolean;
   posture?: string;
   trust_score?: number;
 }
 
 const SERVICE_MAP: Record<string, ServiceEntry> = {
-  ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)" },
-  alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)" },
-  auth:             { binding: "SVC_AUTH",             label: "ChittyAuth (identity + tokens)" },
-  autoassist:       { binding: "SVC_AUTOASSIST",       label: "AutoAssist" },
-  bluebubbles:      { binding: "SVC_BLUEBUBBLES",      label: "BlueBubbles bridge" },
-  canon:            { binding: "SVC_CANON",            label: "Canon (governance)" },
-  ch1tty:           { binding: "SVC_CH1TTY",           label: "Ch1tty Gateway" },
-  chatgpt:          { binding: "SVC_CHATGPT",          label: "ChatGPT Bridge" },
-  cleaner:          { binding: "SVC_CLEANER",          label: "Cleaner" },
-  cloudflare:       { binding: "SVC_CLOUDFLARE",       label: "Cloudflare ops" },
-  dispatch:         { binding: "SVC_DISPATCH",         label: "Dispatch" },
-  dispute:          { binding: "SVC_DISPUTE",          label: "Dispute Management" },
-  evidence:         { binding: "SVC_EVIDENCE",         label: "Evidence Pipeline" },
-  finance:          { binding: "SVC_FINANCE",          label: "Finance (Mercury + Neon)" },
-  gam:              { binding: "SVC_GAM",              label: "Google Workspace Admin" },
-  helper:           { binding: "SVC_HELPER",           label: "Ecosystem Helper" },
-  imessage:         { binding: "SVC_IMESSAGE",         label: "iMessage ops" },
-  market:           { binding: "SVC_MARKET",           label: "ChittyMarket" },
-  neon:             { binding: "SVC_NEON",             label: "Neon Postgres ops" },
-  notes:            { binding: "SVC_NOTES",            label: "Notes & Knowledge" },
-  notion:           { binding: "SVC_NOTION",           label: "Notion workspace ops" },
-  orchestrator:     { binding: "SVC_ORCHESTRATOR",     label: "Orchestrator" },
-  quo:              { binding: "SVC_QUO",              label: "Quo unified messaging" },
-  resolve:          { binding: "SVC_RESOLVE",          label: "Resolve" },
-  sandbox:          { binding: "SVC_SANDBOX",          label: "Code Mode Sandbox" },
-  scrape:           { binding: "SVC_SCRAPE",           label: "Scrape" },
-  ship:             { binding: "SVC_SHIP",             label: "Ship & Deploy" },
-  storage:          { binding: "SVC_STORAGE",          label: "Document Storage" },
-  tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue" },
-  twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge" },
-  viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport" },
+  ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)",            category: "platform" },
+  alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)", category: "platform" },
+  auth:             { binding: "SVC_AUTH",             label: "ChittyAuth (identity + tokens)",     category: "identity" },
+  autoassist:       { binding: "SVC_AUTOASSIST",       label: "AutoAssist",                         category: "communication" },
+  bluebubbles:      { binding: "SVC_BLUEBUBBLES",      label: "BlueBubbles bridge",                 category: "communication" },
+  canon:            { binding: "SVC_CANON",            label: "Canon (governance)",                 category: "governance" },
+  ch1tty:           { binding: "SVC_CH1TTY",           label: "Ch1tty Gateway",                     category: "platform" },
+  chatgpt:          { binding: "SVC_CHATGPT",          label: "ChatGPT Bridge",                     category: "platform" },
+  cleaner:          { binding: "SVC_CLEANER",          label: "Cleaner",                            category: "devops" },
+  cloudflare:       { binding: "SVC_CLOUDFLARE",       label: "Cloudflare ops",                     category: "infra" },
+  dispatch:         { binding: "SVC_DISPATCH",         label: "Dispatch",                           category: "platform" },
+  dispute:          { binding: "SVC_DISPUTE",          label: "Dispute Management",                 category: "communication" },
+  evidence:         { binding: "SVC_EVIDENCE",         label: "Evidence Pipeline",                  category: "legal" },
+  finance:          { binding: "SVC_FINANCE",          label: "Finance (Mercury + Neon)",           category: "finance" },
+  gam:              { binding: "SVC_GAM",              label: "Google Workspace Admin",             category: "infra" },
+  helper:           { binding: "SVC_HELPER",           label: "Ecosystem Helper",                   category: "platform" },
+  imessage:         { binding: "SVC_IMESSAGE",         label: "iMessage ops",                       category: "communication" },
+  market:           { binding: "SVC_MARKET",           label: "ChittyMarket",                       category: "platform" },
+  neon:             { binding: "SVC_NEON",             label: "Neon Postgres ops",                  category: "infra" },
+  notes:            { binding: "SVC_NOTES",            label: "Notes & Knowledge",                  category: "communication" },
+  notion:           { binding: "SVC_NOTION",           label: "Notion workspace ops",               category: "productivity" },
+  orchestrator:     { binding: "SVC_ORCHESTRATOR",     label: "Orchestrator",                       category: "platform" },
+  quo:              { binding: "SVC_QUO",              label: "Quo unified messaging",              category: "communication" },
+  resolve:          { binding: "SVC_RESOLVE",          label: "Resolve",                            category: "devops" },
+  sandbox:          { binding: "SVC_SANDBOX",          label: "Code Mode Sandbox",                  category: "devops" },
+  scrape:           { binding: "SVC_SCRAPE",           label: "Scrape",                             category: "research" },
+  ship:             { binding: "SVC_SHIP",             label: "Ship & Deploy",                      category: "devops" },
+  storage:          { binding: "SVC_STORAGE",          label: "Document Storage",                   category: "infra" },
+  tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue",                        category: "platform" },
+  twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge",                      category: "communication" },
+  viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport",                   category: "platform" },
+};
+
+// Aggregate sub-views: a POST to /{view}/mcp federates only the services whose
+// `category` matches, exposing a focused MCP surface that reuses the same
+// discovery/forward pipeline as the full /mcp aggregate. This makes the
+// CHARTER's per-aggregator membership real (it was doc-only before). New
+// services join a view automatically by declaring the matching category.
+const VIEW_CATEGORIES: Record<string, string> = {
+  cpa: "finance",        // ChittyCPA — money/finance surface (chittyagent-finance, +future stripe/quickbooks/plaid)
+  msg: "communication",  // ChittyMsg — messaging/comms surface (quo, twilio, imessage, bluebubbles, …)
 };
 
 const MCP_REGISTRY_KEY = "services:v1";
@@ -179,7 +196,11 @@ async function loadActiveServices(env: Env): Promise<Record<string, ServiceEntry
     for (const entry of parsed) {
       if (!entry?.id || !entry?.sub || !entry?.binding || !entry?.label) continue;
       if (!isEligibleByPosture(entry)) continue;
-      active[entry.sub] = { binding: entry.binding, label: entry.label };
+      active[entry.sub] = {
+        binding: entry.binding,
+        label: entry.label,
+        category: entry.category || SERVICE_MAP[entry.sub]?.category || "platform",
+      };
     }
     return Object.keys(active).length > 0 ? active : fallback;
   } catch (err) {
@@ -1208,7 +1229,7 @@ async function handleAdminBind(request: Request, env: Env): Promise<Response> {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
-    const path = url.pathname;
+    let path = url.pathname;
 
     // Cheap branches first — these don't need the dynamic service map and
     // shouldn't pay a KV read per request.
@@ -1341,7 +1362,25 @@ export default {
     }
 
     // Everything below depends on the active (posture-filtered) service map.
-    const serviceMap = await loadActiveServices(env);
+    let serviceMap = await loadActiveServices(env);
+
+    // Aggregate sub-view rewrite: a POST to /{view}/mcp (cpa, msg, …) narrows
+    // the map to the services whose `category` matches that view, then rewrites
+    // the path to /mcp so the existing aggregate pipeline (initialize,
+    // tools/list, tools/call, prompts, resources) runs unchanged over the
+    // filtered set. View names never collide with service ids (checked below),
+    // so the per-service proxy loop is unaffected. Fails CLOSED: an empty
+    // filtered map yields an aggregate with zero tools rather than the full set.
+    for (const [view, category] of Object.entries(VIEW_CATEGORIES)) {
+      if (serviceMap[view]) continue; // a real service named like a view wins
+      if (path === `/${view}/mcp` || path.startsWith(`/${view}/mcp/`)) {
+        serviceMap = Object.fromEntries(
+          Object.entries(serviceMap).filter(([, s]) => s.category === category),
+        );
+        path = path.slice(`/${view}`.length) || "/mcp";
+        break;
+      }
+    }
 
     // Service index
     if (request.method === "GET" && (path === "/" || path === "")) {


### PR DESCRIPTION
## What

Adds **category-based aggregate sub-views** to the chittymcp aggregator, implementing the per-aggregator membership the CHARTER previously only *documented* (the `domain:`/`surface:` tag filters were never enforced in code — confirmed: zero filter logic in `src/`).

- **`/cpa/mcp` → ChittyCPA** — `category:finance`. Today surfaces `chittyagent-finance` (6 real Neon+Mercury tools). Future `stripe`/`quickbooks`/`plaid` finance agents auto-join by declaring `category: "finance"`.
- **`/msg/mcp` → ChittyMsg** — `category:communication` (quo, twilio, imessage, bluebubbles, notes, dispute, autoassist). Makes the long-documented ChittyMsg subset real.
- **`/mcp`** — unchanged, all 31 services.

## How

1. `category` field added to every `SERVICE_MAP` entry — reuses ch1tty `servers.json`'s `category` vocabulary (`finance`, `communication`, `platform`, `infra`, …), **not** the dead `domain:` tag.
2. `VIEW_CATEGORIES` maps `cpa→finance`, `msg→communication`.
3. In `fetch()`, after the service map loads, a POST to `/{view}/mcp` filters the map to the matching category and rewrites the path to `/mcp` — so the **entire existing aggregate pipeline** (initialize / tools/list / tools/call / prompts / resources) and the already-proven forwarder run unchanged. **No new tool code.**

### Safety
- **Fails CLOSED**: an empty filtered set yields an aggregate with zero tools, never the full surface.
- View names never shadow a real service id (`serviceMap[view]` guard → per-service proxy wins).
- `loadActiveServices` carries `category` through the dynamic-registry path, defaulting to `platform`.

## Taxonomy reconciliation
Three competing membership models existed (CHARTER `domain:`, triage `policy_filters`, servers.json `category:`). This collapses to the **single implemented `category`** field. `CHARTER.md` and `docs/agent-registry-triage.json` updated to match, with explicit notes that the old tag filters were doc-only.

## Validation
- ✅ `tsc --noEmit`: no new errors (the 4 reported at L309 are pre-existing CF-API payload typings on `main`, untouched).
- ✅ `agent-registry-triage.json` parses.
- ✅ Live `mcp.chitty.cc/` index confirms `finance` is registered and routable (`/finance/mcp`) — the real data `/cpa/mcp` will expose.
- ⏳ **Merge gate**: end-to-end `POST /cpa/mcp {tools/list}` curl **post-deploy** (Worker behavior can only be exercised with prod service bindings). This is the canonical validation path for deployed Workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)