### PR TITLE
fix(oauth): serve path-scoped protected-resource metadata (RFC 9728 §3.1)

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1258,23 +1258,56 @@ export default {
     const TEAM = "https://chittycorp.cloudflareaccess.com";
     const SELF = "https://mcp.chitty.cc";
 
-    if (request.method === "GET" && path === "/.well-known/oauth-protected-resource") {
+    // RFC 9728 §3.1: clients derive the protected-resource metadata URL by
+    // inserting the resource's PATH into the well-known prefix. For an MCP
+    // server advertised as https://mcp.chitty.cc/mcp, Claude.ai fetches
+    // /.well-known/oauth-protected-resource/mcp — NOT the bare root. Serve the
+    // metadata for the root prefix AND any path suffix so path-scoped discovery
+    // resolves (200) instead of 404.
+    //
+    // Authorization server: this host fronts a Cloudflare Access `mcp_portal`
+    // app, which shadows the worker's OAuth endpoints at the edge and routes
+    // the OAuth handshake to the CF Access team domain (verified live: root
+    // AS-metadata issuer = chittycorp.cloudflareaccess.com; DCR to the team
+    // domain returns 201). Advertising SELF as the AS would send clients to
+    // mcp.chitty.cc/.well-known/oauth-authorization-server, whose edge-served
+    // issuer is the team domain — an RFC 8414 §3.3 issuer mismatch that breaks
+    // the connector. So advertise the team domain as the authorization server.
+    // (On hosts WITHOUT mcp_portal, e.g. mcp.ch1tty.com, the worker serves its
+    // own OAuth endpoints and SELF is correct there — this host differs.)
+    if (
+      request.method === "GET" &&
+      (path === "/.well-known/oauth-protected-resource" ||
+        path.startsWith("/.well-known/oauth-protected-resource/"))
+    ) {
+      // RFC 9728 §3.3: echo the full requested resource identifier so the
+      // client's resource-match check passes (root → SELF; /mcp → SELF/mcp).
+      const suffix = path.slice("/.well-known/oauth-protected-resource".length);
+      const resource = suffix ? `${SELF}${suffix}` : SELF;
       return Response.json({
-        resource: SELF,
-        authorization_servers: [SELF],
+        resource,
+        authorization_servers: [TEAM],
         bearer_methods_supported: ["header"],
         resource_documentation: "https://github.com/CHITTYOS/chittymcp/blob/main/docs/MCP-SOP.md",
       }, { headers: corsHeaders() });
     }
 
-    if (request.method === "GET" && path === "/.well-known/oauth-authorization-server") {
-      // Spec-compliant AS metadata advertising worker-hosted endpoints.
+    if (
+      request.method === "GET" &&
+      (path === "/.well-known/oauth-authorization-server" ||
+        path.startsWith("/.well-known/oauth-authorization-server/"))
+    ) {
+      // Authorization server metadata. On this host the edge (mcp_portal)
+      // shadows root and clients use the team-domain AS, so this worker-served
+      // document is not on Claude.ai's critical path; it is kept path-tolerant
+      // for spec completeness and advertises the CF Access team-domain
+      // endpoints to stay consistent with the protected-resource AS above.
       return Response.json({
-        issuer: SELF,
-        authorization_endpoint: `${SELF}/authorize`,
-        token_endpoint: `${SELF}/token`,
-        registration_endpoint: `${SELF}/register`,
-        revocation_endpoint: `${SELF}/token`,
+        issuer: TEAM,
+        authorization_endpoint: `${TEAM}/cdn-cgi/access/oauth/authorization`,
+        token_endpoint: `${TEAM}/cdn-cgi/access/oauth/token`,
+        registration_endpoint: `${TEAM}/cdn-cgi/access/oauth/registration`,
+        revocation_endpoint: `${TEAM}/cdn-cgi/access/oauth/revoke`,
         response_types_supported: ["code"],
         response_modes_supported: ["query"],
         grant_types_supported: ["authorization_code", "refresh_token"],


### PR DESCRIPTION
Path-scoped protected-resource discovery (`/.well-known/oauth-protected-resource/mcp`) returned 404, causing Claude.ai connector 'Not Found'. Handlers now match root prefix AND any path suffix. resource echoes the requested URL; authorization_servers advertises the CF Access team domain (this host fronts an mcp_portal Access app that shadows worker OAuth at the edge — SELF would cause an RFC 8414 issuer mismatch). Deployed + verified live (version 8a178684): path-scoped 404→200, root unchanged 200, POST /mcp still 401+Bearer, DCR still 201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced OAuth discovery endpoints to support flexible resource path resolution, improving metadata routing and discovery capabilities.
  * Updated authorization server configuration to align endpoints with team-domain infrastructure rather than worker-hosted services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->