### PR TITLE
feat(aggregator): federate chittyagent-bindings (MCP-ready only)

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -42,6 +42,7 @@ interface Env {
   SVC_TASKS: Fetcher;
   SVC_TWILIO: Fetcher;
   SVC_VIEWPORT: Fetcher;
+  SVC_BINDINGS: Fetcher;
   // MCP_API_KEY: shared secret required for /mcp aggregator + /{service}/mcp proxy.
   // Set via `wrangler secret put MCP_API_KEY`.
   MCP_API_KEY?: string;
@@ -124,6 +125,7 @@ const SERVICE_MAP: Record<string, ServiceEntry> = {
   tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue" },
   twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge" },
   viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport" },
+  bindings:         { binding: "SVC_BINDINGS",         label: "Service-binding reconciler" },
 };
 
 const MCP_REGISTRY_KEY = "services:v1";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,6 +52,7 @@
     { "binding": "SVC_FINANCE",      "service": "chittyagent-finance" },
     { "binding": "SVC_SANDBOX",      "service": "chittyagent-sandbox" },
     { "binding": "SVC_BLUEBUBBLES", "service": "chittyagent-bluebubbles" },
-    { "binding": "SVC_TWILIO", "service": "chittyagent-twilio" }
+    { "binding": "SVC_TWILIO", "service": "chittyagent-twilio" },
+    { "binding": "SVC_BINDINGS",        "service": "chittyagent-bindings" }
   ]
 }


### PR DESCRIPTION
## What
Federates `chittyagent-bindings`. Aggregator now serves **32** live MCP services.

## Why bindings-only (branch was federate-5)
Live-probed all 5 candidates; only `bindings` is a real MCP server (`initialize` → tools cap). `git`+`schema` are REST-only (no `/mcp`); `human-escalator`+`mcp-builder` are undeployed (DNS 000). Binding those would fail deploy or federate dead endpoints — they're chittyentity work, deferred.

## Verification (live)
- `/v0.1/servers` → count 32, `bindings` present
- `bindings/mcp` enforces Bearer MCP_API_KEY (authed verification via ChittyConnect)
- Deployed version `fce6c3d7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)