### PR TITLE
docs(sop): canonical MCP prompt + resource conventions

### DIFF
--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -49,18 +49,28 @@ Each `chittyagent-<name>` worker MUST expose:
 - DO binding (env): `<NAME>_AGENT` (UPPER_SNAKE)
 
 ### Tool name
-**Pattern:** `<service>_<verb>` or `<service>_<noun>_<verb>`. Lowercase snake.
+**Pattern:** `<verb>` or `<noun>_<verb>` — **BARE. Do NOT prefix with the
+service name.** Lowercase snake. The MCP server name (`chittyagent-<name>`) and
+the aggregator namespace already carry the service; repeating it in the tool
+name is redundant and compounds badly through layers.
 
-| Good                   | Bad                  | Reason |
-|------------------------|----------------------|--------|
-| `tasks_list`           | `listTasks`          | wrong case |
-| `auth_resolve_token`   | `resolveAuthToken`   | wrong case |
-| `evidence_ingest`      | `ingest_evidence`    | verb-last |
-| `tasks_lease_claim`    | `claim`              | not namespaced |
+| Good        | Bad                  | Reason |
+|-------------|----------------------|--------|
+| `list`      | `tasks_list`         | service prefix is redundant (server is already `chittyagent-tasks`) |
+| `search`    | `notes_search`       | `chittyagent-notes` already names the service |
+| `resolve_token` | `auth_resolve_token` | drop the `auth_` prefix |
+| `ingest`    | `ingest_evidence`    | verb-last AND redundant |
+| `list`      | `listTasks`          | wrong case |
 
-Aggregators namespace as `<service>/<tool>` (e.g. `tasks/tasks_list`).
-Keep the service prefix in the inner tool name too — clients that bypass
-the aggregator (direct `<name>.chitty.cc/mcp`) still need self-descriptive names.
+**Why bare (binding):** an aggregator namespaces as `<service>/<tool>` and a
+downstream connector adds its OWN name on top. A service-prefixed tool
+therefore triples the service token end-to-end — e.g. `quo_send_message`
+federated through chittymsg and surfaced via the Chitty_Msg connector becomes
+`Chitty_Msg__chittyagent-quo_quo_send_message` ("quo" ×3). Bare `send_message`
+renders as `Chitty_Msg__chittyagent-quo_send_message` — the service appears
+exactly once, where it belongs (the server name). A client connected directly
+to `<name>.chitty.cc/mcp` already knows which server it called, so bare names
+are still self-descriptive there.
 
 ### Verbs
 Canonical verbs (extend cautiously, document if new):
@@ -68,8 +78,8 @@ Canonical verbs (extend cautiously, document if new):
 heartbeat, resolve, validate, ingest, search, render`.
 
 ### Tool grouping
-If a service has >8 tools, group by capability domain in the tool name:
-`storage_object_put`, `storage_object_get`, `storage_bucket_list`.
+If a service has >8 tools, group by capability domain in the tool name (still
+service-prefix-free): `object_put`, `object_get`, `bucket_list`.
 
 ## 3.5 Prompt & Resource conventions (binding)
 
@@ -79,24 +89,23 @@ canonical reference implementation — read its `src/prompts.ts` and
 `src/resources.ts`.
 
 ### Prompt name
-**Pattern:** `<service>_<verb>` snake_case — **same rule as tools.** The
-aggregator namespaces prompts as `<service>/<prompt>`, so the service prefix
-MUST stay in the inner name for direct-call self-description.
-
-- `quo_triage_inbound`, `quo_summarize_thread`, `imsg_unified_brief` — good.
-- **Bare parity names** (`send_text_message`, `create_contact`) are a
-  sanctioned EXCEPTION, permitted ONLY to shadow a *named external connector's*
-  prompt surface, and MUST carry a justifying comment (e.g.
-  `// Parity prompts — match Quo's official Anthropic connector names`).
-  Absent that, the `<service>_` prefix is mandatory.
+**Pattern:** `<verb>` snake_case — **BARE, same rule as tools (§3).** Do NOT
+prefix with the service name; the server + aggregator namespace already carry
+it. `triage_inbound`, `summarize_thread`, `unified_brief` — good.
+`quo_triage_inbound` — bad (redundant `quo_`).
 
 A prompt body (the rendered `messages[].content.text`) SHOULD name the concrete
-`<service>_*` tools the LLM is expected to call — prompts orchestrate this
-service's own tools by name.
+bare tools the LLM is expected to call — prompts orchestrate this service's own
+tools by name (`search`, `list_messages`, …).
 
 ### Resource URI + name
-**URI scheme:** `<service>://<domain>/<noun>` (kebab segments) — the service's
-OWN scheme. NEVER `chitty://` and NEVER `chittycanon://`.
+**Resource name:** bare `<noun>` (`phone_numbers`, not `quo_phone_numbers`) —
+same bare rule as tools/prompts.
+
+**URI scheme:** `<service>://<domain>/<noun>` (kebab segments). Here the
+`<service>://` *scheme* IS the namespace mechanism for resources (the analog of
+the aggregator's `<service>/` tool prefix), so it names the service exactly
+once — that is correct, not redundant. NEVER `chitty://`, NEVER `chittycanon://`.
 
 | Scheme | Owner | Meaning |
 |--------|-------|---------|
@@ -108,8 +117,8 @@ An MCP resource URI is a transport handle for live data, NOT a canonical graph
 identifier — conflating them with `chittycanon://` is a violation.
 Examples: `quo://phone-numbers`, `quo://config/routing`, `imsg://sync/state`.
 
-- **Resource name** (first arg): `<service>_<noun>` snake_case
-  (`quo_phone_numbers`), mirroring tool naming.
+- **Resource name** (first arg): bare `<noun>` snake_case (`phone_numbers`,
+  NOT `quo_phone_numbers`), mirroring the bare tool/prompt rule.
 - **MIME type:** explicit, always. `application/json` default; `text/markdown`
   for rendered docs; `text/plain` for logs.
 
@@ -159,14 +168,14 @@ const _e = (m: string) => ({
 
 function register<Name>Tools(server: McpServer, env: Env) {
   server.tool(
-    "<service>_<verb>",
+    "<verb>",                         // BARE — no service prefix (§3)
     "<one-line description>",
     { /* zod schema */ },
     async (input) => {
       try {
         const out = await <existingFunction>(env, input);
         return _t(out);
-      } catch (e) { return _e(`<service>_<verb> failed: ${(e as Error).message}`); }
+      } catch (e) { return _e(`<verb> failed: ${(e as Error).message}`); }
     },
   );
   // …more server.tool() calls
@@ -222,11 +231,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function register<Name>Prompts(server: McpServer) {
   server.registerPrompt(
-    "<service>_<verb>",
+    "<verb>",                         // BARE — no service prefix (§3.5)
     { title: "<human label>", description: "<what it does + which tools it orchestrates>",
       argsSchema: { /* zod validators */ } },
     (args) => ({ messages: [{ role: "user", content: { type: "text", text:
-      [ "<task>", "", "Use `<service>_<tool>` to …" ].join("\n") } }] }),
+      [ "<task>", "", "Use `<tool>` to …" ].join("\n") } }] }),
   );
 }
 
@@ -238,7 +247,7 @@ export function register<Name>Resources(
   server: McpServer, env: Env, getCredential: (n: string) => Promise<string>,
 ) {
   server.registerResource(
-    "<service>_<noun>", "<service>://<domain>/<noun>",
+    "<noun>", "<service>://<domain>/<noun>",   // bare name; service lives in the URI scheme
     { title: "<label>", description: "<live data this serves>", mimeType: "application/json" },
     async (uri) => {
       const data = await /* real REST client / Neon query / env config */;

--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -71,6 +71,70 @@ heartbeat, resolve, validate, ingest, search, render`.
 If a service has >8 tools, group by capability domain in the tool name:
 `storage_object_put`, `storage_object_get`, `storage_bucket_list`.
 
+## 3.5 Prompt & Resource conventions (binding)
+
+Ratified from live precedent in `chittyagent-quo` and `chittyagent-imessage`
+(the first two workers to ship prompts + resources). `chittyagent-quo` is the
+canonical reference implementation — read its `src/prompts.ts` and
+`src/resources.ts`.
+
+### Prompt name
+**Pattern:** `<service>_<verb>` snake_case — **same rule as tools.** The
+aggregator namespaces prompts as `<service>/<prompt>`, so the service prefix
+MUST stay in the inner name for direct-call self-description.
+
+- `quo_triage_inbound`, `quo_summarize_thread`, `imsg_unified_brief` — good.
+- **Bare parity names** (`send_text_message`, `create_contact`) are a
+  sanctioned EXCEPTION, permitted ONLY to shadow a *named external connector's*
+  prompt surface, and MUST carry a justifying comment (e.g.
+  `// Parity prompts — match Quo's official Anthropic connector names`).
+  Absent that, the `<service>_` prefix is mandatory.
+
+A prompt body (the rendered `messages[].content.text`) SHOULD name the concrete
+`<service>_*` tools the LLM is expected to call — prompts orchestrate this
+service's own tools by name.
+
+### Resource URI + name
+**URI scheme:** `<service>://<domain>/<noun>` (kebab segments) — the service's
+OWN scheme. NEVER `chitty://` and NEVER `chittycanon://`.
+
+| Scheme | Owner | Meaning |
+|--------|-------|---------|
+| `chittycanon://` | ChittyGov | canonical governance/service **identity** in the graph |
+| `chitty://` | reserved | ecosystem-internal cross-service references |
+| `<service>://` | the worker | **MCP resource handles** — live, read-only runtime data |
+
+An MCP resource URI is a transport handle for live data, NOT a canonical graph
+identifier — conflating them with `chittycanon://` is a violation.
+Examples: `quo://phone-numbers`, `quo://config/routing`, `imsg://sync/state`.
+
+- **Resource name** (first arg): `<service>_<noun>` snake_case
+  (`quo_phone_numbers`), mirroring tool naming.
+- **MIME type:** explicit, always. `application/json` default; `text/markdown`
+  for rendered docs; `text/plain` for logs.
+
+### Argument schema
+Plain object of Zod validators (NOT a wrapped `z.object()`):
+`argsSchema: { from: e164, body: z.string().min(1) }`. Constrain types
+semantically (shared `e164` regex, `.min(1)`, `.int().min().max()`). Use
+`.describe()` on any argument whose purpose isn't obvious from its name.
+
+### Capabilities
+SDK-derived — do NOT hand-write the `capabilities` block. Calling
+`registerPrompt` / `registerResource` in `init()` makes McpServer advertise the
+`prompts` / `resources` capabilities automatically. Leave `listChanged` /
+`subscribe` OFF unless the list is dynamic or you actually honor
+`resources/subscribe` (declaring `subscribe` without implementing it is a
+non-working-endpoint violation).
+
+### @canon citation
+Cite canon ONCE at the module header of `prompts.ts` / `resources.ts`:
+```ts
+// @canon: chittycanon://gov/governance#core-types
+// @canonical-uri: chittycanon://core/services/chittyagent-<name>
+```
+Do NOT scatter P/L/T/E/A references into individual prompts.
+
 ## 4. The McpAgent wrap (canonical template)
 
 There is **no shared `McpAgent` base class** in `workers/shared/` — `agents/mcp`
@@ -145,6 +209,56 @@ export default {
 ]
 ```
 
+### The prompt/resource wrap (canonical template)
+
+Keep prompts and resources in **separate files** (`prompts.ts`, `resources.ts`) —
+do not inline into the agent class. Register them in `init()` alongside tools.
+
+```ts
+// src/prompts.ts — static templates, no env needed
+// @canon: chittycanon://gov/governance#core-types
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function register<Name>Prompts(server: McpServer) {
+  server.registerPrompt(
+    "<service>_<verb>",
+    { title: "<human label>", description: "<what it does + which tools it orchestrates>",
+      argsSchema: { /* zod validators */ } },
+    (args) => ({ messages: [{ role: "user", content: { type: "text", text:
+      [ "<task>", "", "Use `<service>_<tool>` to …" ].join("\n") } }] }),
+  );
+}
+
+// src/resources.ts — LIVE data only, no mocks (see §6)
+// @canon: chittycanon://gov/governance#core-types
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function register<Name>Resources(
+  server: McpServer, env: Env, getCredential: (n: string) => Promise<string>,
+) {
+  server.registerResource(
+    "<service>_<noun>", "<service>://<domain>/<noun>",
+    { title: "<label>", description: "<live data this serves>", mimeType: "application/json" },
+    async (uri) => {
+      const data = await /* real REST client / Neon query / env config */;
+      return { contents: [{ uri: uri.href, mimeType: "application/json",
+        text: JSON.stringify(data, null, 2) }] };
+    },
+  );
+}
+
+// in the agent: async init() {
+//   register<Name>Tools(this.server, this.env);
+//   register<Name>Prompts(this.server);
+//   register<Name>Resources(this.server, this.env, (n) => resolveCredential(this.env, n, SERVICE));
+// }
+```
+
+**No-resource is a valid outcome.** If a service has no real live data to expose
+(a pure-action worker), ship prompts only and say so — do NOT fabricate a
+resource to fill the slot. Mock resources violate §6.
+
 ## 5. Endpoints (binding)
 
 Every service MCP MUST be reachable at three addresses, all serving identical
@@ -166,7 +280,9 @@ clients SHOULD prefer `canonical`.
 - No placeholder route bodies. Every tool calls a real implementation.
 - No `vi.mock(...)` on DB/service modules in new tests.
 - Every PR body MUST include a real `tools/list` curl output from the
-  deployed endpoint as evidence the wrap landed.
+  deployed endpoint as evidence the wrap landed. When the PR adds prompts or
+  resources, it MUST also include `prompts/list` and `resources/list` output
+  from the deployed endpoint — every resource proven to return live data.
 
 ## 7. Step-by-step (the procedure)
 

--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -283,6 +283,18 @@ clients SHOULD prefer `canonical`.
   deployed endpoint as evidence the wrap landed. When the PR adds prompts or
   resources, it MUST also include `prompts/list` and `resources/list` output
   from the deployed endpoint — every resource proven to return live data.
+- Generate that evidence with **`scripts/verify-mcp.sh`** — it runs the full
+  `initialize → tools/list → prompts/list → resources/list` handshake (and
+  `--read` proves every resource returns live data):
+  ```bash
+  scripts/verify-mcp.sh <service> --read          # canonical <name>.chitty.cc
+  scripts/verify-mcp.sh <service> --origin --read  # if the canonical domain is Access-gated
+  MCP_BEARER=$KEY scripts/verify-mcp.sh mcp.chitty.cc/<service>/mcp  # aggregated path
+  ```
+- **Verification ≠ persistence.** Deploying an unmerged branch to production to
+  capture this evidence is transient — the next deploy of that worker from
+  `main` reverts it. The prompts/resources are durable ONLY once the PR merges.
+  Treat the PR as the source of truth, not the live-but-unmerged deployment.
 
 ## 7. Step-by-step (the procedure)
 

--- a/scripts/verify-mcp.sh
+++ b/scripts/verify-mcp.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# verify-mcp.sh — produce the canonical MCP evidence required by MCP-SOP §6.
+#
+# Initializes a streamable-HTTP MCP session against a service endpoint, then
+# lists tools / prompts / resources and reads each resource to prove it returns
+# real data (not a mock). Emits a compact evidence block suitable for pasting
+# into a PR body.
+#
+# Usage:
+#   scripts/verify-mcp.sh <service>            # → https://<service>.chitty.cc/mcp
+#   scripts/verify-mcp.sh <url>                # any full https://.../mcp endpoint
+#   scripts/verify-mcp.sh <service> --origin   # → https://chittyagent-<service>.ccorp.workers.dev/mcp
+#                                              #   (use when the canonical domain is CF-Access-gated)
+#   MCP_BEARER=xxx scripts/verify-mcp.sh ...   # send Authorization: Bearer (aggregator path)
+#   scripts/verify-mcp.sh <service> --read     # also resources/read every resource (proves live data)
+#
+# Exit codes: 0 = initialize + tools/list succeeded; 1 = usage; 2 = endpoint unreachable/unauthorized.
+set -euo pipefail
+
+ARG="${1:-}"
+[ -z "$ARG" ] && { echo "usage: $0 <service|url> [--origin] [--read]"; exit 1; }
+shift || true
+
+ORIGIN=0; READ=0
+for f in "$@"; do
+  case "$f" in
+    --origin) ORIGIN=1 ;;
+    --read)   READ=1 ;;
+    *) echo "unknown flag: $f"; exit 1 ;;
+  esac
+done
+
+case "$ARG" in
+  https://*) URL="$ARG" ;;
+  *) if [ "$ORIGIN" = 1 ]; then URL="https://chittyagent-${ARG}.ccorp.workers.dev/mcp"; else URL="https://${ARG}.chitty.cc/mcp"; fi ;;
+esac
+
+AUTH=(); [ -n "${MCP_BEARER:-}" ] && AUTH=(-H "authorization: Bearer ${MCP_BEARER}")
+ACCEPT="application/json, text/event-stream"
+CT="content-type: application/json"
+
+# Parse a JSON-RPC response body (plain JSON or SSE `data:` framed) and pull a
+# named field out of result.<key>[]. Robust against prompt argument `name`s
+# (which would pollute a naive grep) by reading only top-level list items.
+#   field <body> <list> <item-field>   e.g. field "$P" prompts name
+field() {
+  MCP_BODY="$1" python3 - "$2" "$3" <<'PY'
+import os, sys, json
+listk, itemk = sys.argv[1], sys.argv[2]
+raw = os.environ.get("MCP_BODY", "")
+obj = None
+for line in raw.splitlines():
+    line = line[6:] if line.startswith("data: ") else line
+    line = line.strip()
+    if not line.startswith("{"): continue
+    try: o = json.loads(line)
+    except Exception: continue
+    if isinstance(o, dict) and ("result" in o or "error" in o): obj = o
+if obj is None: print("__none__"); sys.exit()
+if "error" in obj: print("__error__:" + str(obj["error"].get("code")) + ":" + obj["error"].get("message","")); sys.exit()
+items = (obj.get("result") or {}).get(listk) or []
+print("\n".join(str(i.get(itemk,"")) for i in items))
+PY
+}
+
+rpc() { # rpc <session-id-or-empty> <json-body>  → prints raw response body
+  local sid="$1"; shift
+  local hdr=(); [ -n "$sid" ] && hdr=(-H "mcp-session-id: $sid")
+  curl -fsS --max-time 25 -X POST "$URL" -H "$CT" -H "accept: $ACCEPT" "${AUTH[@]}" "${hdr[@]}" -d "$1" 2>/dev/null
+}
+joined() { paste -sd, - | sed 's/,/, /g'; }  # newline list → "a, b, c"
+
+echo "── MCP verification: $URL ──"
+
+# 1. initialize (capture session id from response headers)
+HDRS="$(curl -fsS --max-time 25 -D - -o /dev/null -X POST "$URL" -H "$CT" -H "accept: $ACCEPT" "${AUTH[@]}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify-mcp","version":"1"}}}' 2>/dev/null)" || {
+    echo "  initialize FAILED (unreachable / unauthorized). Try --origin if the canonical domain is Access-gated, or set MCP_BEARER for the aggregator path."; exit 2; }
+SID="$(printf '%s' "$HDRS" | grep -ai '^mcp-session-id:' | tr -d '\r' | awk '{print $2}')"
+echo "  session: ${SID:-<none>}"
+
+names() { local out; out="$(field "$1" "$2" "$3")"; [ "$out" = "__none__" ] && return 2
+  case "$out" in __error__:*) return 3;; esac
+  printf '%s' "$out"; }
+# Describe why a list call returned nothing, from the raw body.
+why() { if printf '%s' "$1" | grep -q '\-32601'; then echo "unsupported (-32601)"; else echo "error/empty"; fi; }
+
+TOOLS="$(rpc "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
+T="$(names "$TOOLS" tools name)"; n=$(printf '%s' "$T" | grep -c . || true)
+echo "  tools/list:     ${n} — $(printf '%s' "$T" | head -8 | joined)"
+
+PROMPTS="$(rpc "$SID" '{"jsonrpc":"2.0","id":3,"method":"prompts/list"}')"
+if P="$(names "$PROMPTS" prompts name)"; then n=$(printf '%s' "$P" | grep -c . || true)
+  echo "  prompts/list:   ${n} — $(printf '%s' "$P" | joined)"
+else echo "  prompts/list:   $(why "$PROMPTS")"; fi
+
+RES="$(rpc "$SID" '{"jsonrpc":"2.0","id":4,"method":"resources/list"}')"
+if URIS="$(names "$RES" resources uri)"; then n=$(printf '%s' "$URIS" | grep -c . || true)
+  echo "  resources/list: ${n} — $(printf '%s' "$URIS" | joined)"
+  if [ "$READ" = 1 ] && [ -n "$URIS" ]; then
+    echo "  resources/read:"
+    while IFS= read -r u; do [ -z "$u" ] && continue
+      body="$(rpc "$SID" "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"resources/read\",\"params\":{\"uri\":\"$u\"}}")"
+      txt="$(field "$body" contents text | head -1)"
+      if printf '%s' "$body" | grep -q '"error"'; then echo "    $u → ERROR"
+      elif [ -n "$txt" ] && [ "$txt" != "__none__" ]; then echo "    $u → live: $(printf '%s' "$txt" | tr -d '\n' | cut -c1-70)…"
+      else echo "    $u → (read returned no text)"; fi
+    done <<< "$URIS"
+  fi
+else echo "  resources/list: $(why "$RES")"; fi
+echo "── ok ──"

--- a/scripts/verify-mcp.sh
+++ b/scripts/verify-mcp.sh
@@ -14,13 +14,41 @@
 #                                              #   (use when the canonical domain is CF-Access-gated)
 #   MCP_BEARER=xxx scripts/verify-mcp.sh ...   # send Authorization: Bearer (aggregator path)
 #   scripts/verify-mcp.sh <service> --read     # also resources/read every resource (proves live data)
+#   scripts/verify-mcp.sh --all                # sweep every federated service (live list from the aggregator)
+#                                              #   canonical first, --origin fallback; summary table
 #
 # Exit codes: 0 = initialize + tools/list succeeded; 1 = usage; 2 = endpoint unreachable/unauthorized.
 set -euo pipefail
 
 ARG="${1:-}"
-[ -z "$ARG" ] && { echo "usage: $0 <service|url> [--origin] [--read]"; exit 1; }
+[ -z "$ARG" ] && { echo "usage: $0 <service|url|--all> [--origin] [--read]"; exit 1; }
 shift || true
+
+# ── --all: fleet sweep ───────────────────────────────────────────────
+# Pull the live federated-service list from the aggregator, verify each
+# (canonical domain, then chittyagent-<svc>.ccorp.workers.dev fallback),
+# and print a prompts/resources presence table. Self-invokes per service.
+if [ "$ARG" = "--all" ]; then
+  AGG="${MCP_AGG:-https://mcp.chitty.cc}"
+  SVCS="$(curl -fsS --max-time 20 "$AGG/v0.1/servers" 2>/dev/null | python3 -c 'import sys,json;print("\n".join(s["id"] for s in json.load(sys.stdin).get("servers",[])))')"
+  [ -z "$SVCS" ] && { echo "could not fetch service list from $AGG/v0.1/servers"; exit 2; }
+  printf "%-14s %-7s %-12s %-12s %s\n" SERVICE tools prompts resources via
+  while IFS= read -r s; do
+    [ -z "$s" ] && continue
+    out="$("$0" "$s" 2>/dev/null || true)";        via=canonical
+    if ! printf '%s' "$out" | grep -q "── ok ──"; then
+      out="$("$0" "$s" --origin 2>/dev/null || true)"; via=origin
+    fi
+    if ! printf '%s' "$out" | grep -q "── ok ──"; then
+      printf "%-14s %-7s %-12s %-12s %s\n" "$s" "-" "-" "-" "unreachable"; continue
+    fi
+    t=$(printf '%s' "$out" | grep 'tools/list:'     | grep -oE '[0-9]+' | head -1)
+    p=$(printf '%s' "$out" | grep 'prompts/list:'   | grep -oE '[0-9]+|unsupported' | head -1)
+    r=$(printf '%s' "$out" | grep 'resources/list:' | grep -oE '[0-9]+|unsupported' | head -1)
+    printf "%-14s %-7s %-12s %-12s %s\n" "$s" "${t:-?}" "${p:-?}" "${r:-?}" "$via"
+  done <<< "$SVCS"
+  exit 0
+fi
 
 ORIGIN=0; READ=0
 for f in "$@"; do


### PR DESCRIPTION
Codifies prompt/resource conventions into `docs/MCP-SOP.md`, ratifying live precedent from `chittyagent-quo` + `chittyagent-imessage` (both verified live with tools+prompts+resources).

- **§3.5** prompt names `<service>_<verb>`; resource URIs `<service>://<domain>/<noun>` (never `chitty://`/`chittycanon://`); SDK-derived capabilities; `@canon` header.
- **§4.5** wrap template + 'no-resource is valid, never fabricate a mock resource'.
- **§6** PRs adding prompts/resources need deployed `prompts/list`+`resources/list` evidence.

Authored with chittycanon-code-cardinal. Governs the rollout adding prompts/resources to the remaining tools-only workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised binding conventions for tools, prompts, and resources: bare-name requirements, prompt/resource naming, URI scheme, MIME/type and schema guidance, registration and advertising rules, canonical templates for separating prompts and resources, and required `@canon` citation pattern
  * Strengthened review rules: deployment evidence required for prompts/resources and tightened no-mocks policy

* **Tools**
  * Added a verifier script to validate live endpoints, enumerate tools/prompts/resources, and optionally perform live resource reads and federated checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->