### PR TITLE
chore(git): ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ mcp-diagnostics-*.html
 .backups/
 *.bak
 .tmp-oauth.mjs
+
+# Claude Code session worktrees (local only)
+.claude/worktrees/


### PR DESCRIPTION
Claude Code creates per-session git worktrees under `.claude/worktrees/` (e.g. the federate-5-mcps worktree). These are local scratch and were showing as untracked in every session. Ignore them. `.claude/mcp.json` (repo-level MCP config) stays tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)