### PR TITLE
feat(aggregator): auto-bind chittyagent-ui

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -42,6 +42,7 @@ interface Env {
   SVC_TASKS: Fetcher;
   SVC_TWILIO: Fetcher;
   SVC_VIEWPORT: Fetcher;
+  SVC_UI: Fetcher;
   // MCP_API_KEY: shared secret required for /mcp aggregator + /{service}/mcp proxy.
   // Set via `wrangler secret put MCP_API_KEY`.
   MCP_API_KEY?: string;
@@ -124,6 +125,7 @@ const SERVICE_MAP: Record<string, ServiceEntry> = {
   tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue" },
   twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge" },
   viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport" },
+  ui: { binding: "SVC_UI", label: "Ui (auto-bound)" },
 };
 
 const MCP_REGISTRY_KEY = "services:v1";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,6 +52,8 @@
     { "binding": "SVC_FINANCE",      "service": "chittyagent-finance" },
     { "binding": "SVC_SANDBOX",      "service": "chittyagent-sandbox" },
     { "binding": "SVC_BLUEBUBBLES", "service": "chittyagent-bluebubbles" },
-    { "binding": "SVC_TWILIO", "service": "chittyagent-twilio" }
+    { "binding": "SVC_TWILIO", "service": "chittyagent-twilio" },
+    { "binding": "SVC_UI", "service": "chittyagent-ui" }
+  
   ]
 }


### PR DESCRIPTION
Auto-bind triggered by post-deploy beacon from `chittyagent-ui`.

- url: https://ui.chitty.cc
- deploy_id: `n/a`
- commit_sha: `3defaedd0ffa983bc1f64cc0c99ad5b7626211e2`

Adds:
- `SVC_UI: Fetcher` to `Env`
- `ui` entry to `SERVICE_MAP`
- `{ binding: "SVC_UI", service: "chittyagent-ui" }` to `wrangler.jsonc` services[]

Once merged + deployed, aggregator surfaces tools at `mcp.chitty.cc/ui/mcp`.