### PR TITLE
feat(aggregator): federate chittyagent-contextual

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -20,6 +20,7 @@ interface Env {
   SVC_CH1TTY: Fetcher;
   SVC_CHATGPT: Fetcher;
   SVC_CLEANER: Fetcher;
+  SVC_CONTEXTUAL: Fetcher;
   SVC_CLOUDFLARE: Fetcher;
   SVC_DISPATCH: Fetcher;
   SVC_DISPUTE: Fetcher;
@@ -103,6 +104,7 @@ const SERVICE_MAP: Record<string, ServiceEntry> = {
   ch1tty:           { binding: "SVC_CH1TTY",           label: "Ch1tty Gateway" },
   chatgpt:          { binding: "SVC_CHATGPT",          label: "ChatGPT Bridge" },
   cleaner:          { binding: "SVC_CLEANER",          label: "Cleaner" },
+  contextual:       { binding: "SVC_CONTEXTUAL",       label: "Contextual (cross-channel conversations)" },
   cloudflare:       { binding: "SVC_CLOUDFLARE",       label: "Cloudflare ops" },
   dispatch:         { binding: "SVC_DISPATCH",         label: "Dispatch" },
   dispute:          { binding: "SVC_DISPUTE",          label: "Dispute Management" },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,6 +30,7 @@
     { "binding": "SVC_CH1TTY",       "service": "chittyagent-ch1tty" },
     { "binding": "SVC_CHATGPT",      "service": "chittyagent-chatgpt" },
     { "binding": "SVC_CLEANER",      "service": "chittyagent-cleaner" },
+    { "binding": "SVC_CONTEXTUAL",   "service": "chittyagent-contextual" },
     { "binding": "SVC_DISPATCH",     "service": "chittyagent-dispatch" },
     { "binding": "SVC_DISPUTE",      "service": "chittyagent-dispute" },
     { "binding": "SVC_EVIDENCE",     "service": "chittyagent-evidence" },


### PR DESCRIPTION
## What

Federates the new `chittyagent-contextual` worker (cross-channel conversation intelligence over the populated `contextual` store) into the chittymcp aggregator.

Depends on CHITTYOS/chittyentity#491 (the worker). The worker is already deployed and live.

## Changes

- `wrangler.jsonc`: add `SVC_CONTEXTUAL` → `chittyagent-contextual` service binding.
- `src/worker/index.ts`: add `SVC_CONTEXTUAL` to the `Env` interface + `contextual` to `SERVICE_MAP` (label "Contextual (cross-channel conversations)").

The aggregator discovers the 9 bare tools via the same per-binding `initialize` + `tools/list` path as every other federated service.

## Live verification (deployed)

```
$ curl -s https://mcp.chitty.cc/v0.1/servers | jq '.servers[] | select(.id=="contextual")'
{
  "id": "contextual",
  "name": "chittyagent-contextual",
  "label": "Contextual (cross-channel conversations)",
  "transport": "streamable-http",
  "endpoints": {
    "aggregated": "https://mcp.chitty.cc/contextual/mcp",
    "canonical": "https://contextual.chitty.cc/mcp"
  }
}
```

Deploy output confirms the binding attached: `env.SVC_CONTEXTUAL (chittyagent-contextual)  Worker`. Server count went 32 → 33.

The upstream worker's 9 bare tools are verified live (see chittyentity#491): `get_analytics` returns `messagesIngested: 16534`; `search_messages q="payment"` returns real openphone messages.

## chittymsg note

The `/msg` subview membership mechanism (the `category` field on `SERVICE_MAP` entries) lives on the **unmerged** branch `feat/aggregate-subviews-chittycpa` (PR #123), not on `main`. So `contextual` cannot be added to the `domain:messaging` membership in this PR. **When #123 lands**, add `category: "communication"` to the `contextual` entry — it then joins `/msg/mcp` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)