### PR TITLE
fix(aggregator): restore VIEW_CATEGORIES + category fields — prod 1101 hotfix

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -102,39 +102,48 @@ interface DynamicServiceEntry {
 }
 
 const SERVICE_MAP: Record<string, ServiceEntry> = {
-  ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)" },
-  alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)" },
-  auth:             { binding: "SVC_AUTH",             label: "ChittyAuth (identity + tokens)" },
-  autoassist:       { binding: "SVC_AUTOASSIST",       label: "AutoAssist" },
-  bluebubbles:      { binding: "SVC_BLUEBUBBLES",      label: "BlueBubbles bridge" },
-  canon:            { binding: "SVC_CANON",            label: "Canon (governance)" },
-  ch1tty:           { binding: "SVC_CH1TTY",           label: "Ch1tty Gateway" },
-  chatgpt:          { binding: "SVC_CHATGPT",          label: "ChatGPT Bridge" },
-  cleaner:          { binding: "SVC_CLEANER",          label: "Cleaner" },
-  contextual:       { binding: "SVC_CONTEXTUAL",       label: "Contextual (cross-channel conversations)" },
-  cloudflare:       { binding: "SVC_CLOUDFLARE",       label: "Cloudflare ops" },
-  dispatch:         { binding: "SVC_DISPATCH",         label: "Dispatch" },
-  dispute:          { binding: "SVC_DISPUTE",          label: "Dispute Management" },
-  evidence:         { binding: "SVC_EVIDENCE",         label: "Evidence Pipeline" },
-  finance:          { binding: "SVC_FINANCE",          label: "Finance (Mercury + Neon)" },
-  gam:              { binding: "SVC_GAM",              label: "Google Workspace Admin" },
-  helper:           { binding: "SVC_HELPER",           label: "Ecosystem Helper" },
-  imessage:         { binding: "SVC_IMESSAGE",         label: "iMessage ops" },
-  market:           { binding: "SVC_MARKET",           label: "ChittyMarket" },
-  neon:             { binding: "SVC_NEON",             label: "Neon Postgres ops" },
-  notes:            { binding: "SVC_NOTES",            label: "Notes & Knowledge" },
-  notion:           { binding: "SVC_NOTION",           label: "Notion workspace ops" },
-  orchestrator:     { binding: "SVC_ORCHESTRATOR",     label: "Orchestrator" },
-  quo:              { binding: "SVC_QUO",              label: "Quo unified messaging" },
-  resolve:          { binding: "SVC_RESOLVE",          label: "Resolve" },
-  sandbox:          { binding: "SVC_SANDBOX",          label: "Code Mode Sandbox" },
-  scrape:           { binding: "SVC_SCRAPE",           label: "Scrape" },
-  ship:             { binding: "SVC_SHIP",             label: "Ship & Deploy" },
-  storage:          { binding: "SVC_STORAGE",          label: "Document Storage" },
-  tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue" },
-  twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge" },
-  viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport" },
-  ui: { binding: "SVC_UI", label: "Ui (auto-bound)" },
+  ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)",            category: "platform" },
+  alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)", category: "platform" },
+  auth:             { binding: "SVC_AUTH",             label: "ChittyAuth (identity + tokens)",     category: "identity" },
+  autoassist:       { binding: "SVC_AUTOASSIST",       label: "AutoAssist",                         category: "communication" },
+  bluebubbles:      { binding: "SVC_BLUEBUBBLES",      label: "BlueBubbles bridge",                 category: "communication" },
+  canon:            { binding: "SVC_CANON",            label: "Canon (governance)",                 category: "governance" },
+  ch1tty:           { binding: "SVC_CH1TTY",           label: "Ch1tty Gateway",                     category: "platform" },
+  chatgpt:          { binding: "SVC_CHATGPT",          label: "ChatGPT Bridge",                     category: "platform" },
+  cleaner:          { binding: "SVC_CLEANER",          label: "Cleaner",                            category: "devops" },
+  contextual:       { binding: "SVC_CONTEXTUAL",       label: "Contextual (cross-channel conversations)", category: "platform" },
+  cloudflare:       { binding: "SVC_CLOUDFLARE",       label: "Cloudflare ops",                     category: "infra" },
+  dispatch:         { binding: "SVC_DISPATCH",         label: "Dispatch",                           category: "platform" },
+  dispute:          { binding: "SVC_DISPUTE",          label: "Dispute Management",                 category: "communication" },
+  evidence:         { binding: "SVC_EVIDENCE",         label: "Evidence Pipeline",                  category: "legal" },
+  finance:          { binding: "SVC_FINANCE",          label: "Finance (Mercury + Neon)",           category: "finance" },
+  gam:              { binding: "SVC_GAM",              label: "Google Workspace Admin",             category: "infra" },
+  helper:           { binding: "SVC_HELPER",           label: "Ecosystem Helper",                   category: "platform" },
+  imessage:         { binding: "SVC_IMESSAGE",         label: "iMessage ops",                       category: "communication" },
+  market:           { binding: "SVC_MARKET",           label: "ChittyMarket",                       category: "platform" },
+  neon:             { binding: "SVC_NEON",             label: "Neon Postgres ops",                  category: "infra" },
+  notes:            { binding: "SVC_NOTES",            label: "Notes & Knowledge",                  category: "communication" },
+  notion:           { binding: "SVC_NOTION",           label: "Notion workspace ops",               category: "productivity" },
+  orchestrator:     { binding: "SVC_ORCHESTRATOR",     label: "Orchestrator",                       category: "platform" },
+  quo:              { binding: "SVC_QUO",              label: "Quo unified messaging",              category: "communication" },
+  resolve:          { binding: "SVC_RESOLVE",          label: "Resolve",                            category: "devops" },
+  sandbox:          { binding: "SVC_SANDBOX",          label: "Code Mode Sandbox",                  category: "devops" },
+  scrape:           { binding: "SVC_SCRAPE",           label: "Scrape",                             category: "research" },
+  ship:             { binding: "SVC_SHIP",             label: "Ship & Deploy",                      category: "devops" },
+  storage:          { binding: "SVC_STORAGE",          label: "Document Storage",                   category: "infra" },
+  tasks:            { binding: "SVC_TASKS",            label: "Tasks Queue",                        category: "platform" },
+  twilio:           { binding: "SVC_TWILIO",           label: "Twilio bridge",                      category: "communication" },
+  viewport:         { binding: "SVC_VIEWPORT",         label: "Session Viewport",                   category: "platform" },
+  ui:               { binding: "SVC_UI",               label: "Ui (auto-bound)",                    category: "platform" },
+};
+
+// Aggregate sub-views: a POST to /{view}/mcp federates only the services whose
+// `category` matches, exposing a focused MCP surface that reuses the same
+// discovery/forward pipeline as the full /mcp aggregate. New services join a
+// view automatically by declaring the matching category in SERVICE_MAP.
+const VIEW_CATEGORIES: Record<string, string> = {
+  cpa: "finance",        // ChittyCPA — money/finance surface
+  msg: "communication",  // ChittyMsg — messaging/comms surface
 };
 
 const MCP_REGISTRY_KEY = "services:v1";


### PR DESCRIPTION
## Root Cause

Commits #128 (auto-bind chittyagent-ui) and #129 (auto-bind chittyagent-contextual) used `patchWorkerIndex` to append `SERVICE_MAP` entries without the required `category:` field. Their rebase onto main also dropped the `VIEW_CATEGORIES` constant definition that PR #123 introduced.

Result: every `POST /mcp` request hit `ReferenceError: VIEW_CATEGORIES is not defined` at runtime immediately after auth passed (line 1401) → Cloudflare 1101 worker exception → HTTP 500 to all MCP clients.

Pre-deploy the endpoint returned a clean 401 with `WWW-Authenticate: Bearer`. Post-deploy it returned 500. The well-known GET fix from #124 was NOT the cause — that code path is not involved.

## Fix

- Restored `VIEW_CATEGORIES` constant (exact definition from PR #123)
- Added `category:` field to all 33 `SERVICE_MAP` entries (ui and contextual default to `"platform"`)
- Zero new TypeScript errors (4 pre-existing CF-API typings unchanged per #123 commit message)

## Deploy + Verification (live, 2026-06-14)

This fix was deployed to production before the PR (to restore service):
- **Version ID**: `25c7f141-255e-4d99-8944-552a7eb71cc0`

Post-deploy live verification:
- `POST https://mcp.chitty.cc/mcp` → **401** (was 500) ✓
- `GET /.well-known/oauth-protected-resource/mcp` → **200** ✓
- `GET /.well-known/oauth-protected-resource` → **200** ✓

## Prevention

The `patchWorkerIndex` auto-bind function must be updated to inject `category: "platform"` on auto-bound entries. Tracked as follow-up — the immediate regression is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Service definitions now include categorization field, aligning with existing filtering logic
* **Documentation**
  * Added documentation describing how service views are derived from categorization and extensibility patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->