### PR TITLE
docs(sop): §3.6 baseline tools, §3.7 ChatGPT conformance, portal-interop notes

### DIFF
--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -144,6 +144,33 @@ Cite canon ONCE at the module header of `prompts.ts` / `resources.ts`:
 ```
 Do NOT scatter P/L/T/E/A references into individual prompts.
 
+## 3.6 Baseline tools (binding — every service MCP)
+
+Every ChittyOS MCP server MUST expose these meta-tools, named exactly (bare,
+per §3):
+
+| Tool | Contract |
+|------|----------|
+| `status` | Returns `{service, version, status, deps?}` — the MCP mirror of the `/health` HTTP endpoint. Real-dependency probe, no mocks (§6). |
+| `describe` | Returns the service's full surface: `{service, version, canonical_uri, tools: [{name, description}], prompts: [...], resources: [...]}`. Self-documenting; the payload is the same shape POSTed to ChittySchema (below). |
+
+### Schema self-registration (binding)
+On deploy (or first `init()`), every service MUST register its tool surface
+with the canonical registry:
+
+```
+POST https://schema.chitty.cc/api/tools/register
+{ "server": "chittyagent-<name>", "name": "<bare_tool_name>",
+  "description": "...", "inputSchema": { ... } }
+```
+
+one POST per tool, bare names only (ChittySchema keys them
+`tool:chittyagent-<name>:<bare_name>`). The gatekeeper compliance check treats
+an MCP-serving worker with zero entries at
+`GET schema.chitty.cc/api/tools/chittyagent-<name>` as non-compliant.
+Implementation lives in `workers/shared/baseline-tools.ts` (chittyentity) —
+use it; do not hand-roll.
+
 ## 4. The McpAgent wrap (canonical template)
 
 There is **no shared `McpAgent` base class** in `workers/shared/` — `agents/mcp`

--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -183,6 +183,30 @@ an MCP-serving worker with zero entries at
 Implementation lives in `workers/shared/baseline-tools.ts` (chittyentity) —
 use it; do not hand-roll.
 
+## 3.7 ChatGPT surface conformance (binding for ChatGPT-exposed services)
+
+Per OpenAI MCP docs (verified 2026-07-13): ChatGPT connectors, deep research,
+and company knowledge only include servers implementing tools named exactly
+`search` and `fetch` (bare — another reason §3 bans service prefixes) with
+EXACT input signatures:
+
+- `search` — input `{ query: string }`
+- `fetch` — input `{ id: string }`
+
+Compatibility is checked on input parameters only, but return the recommended
+shapes so citations work: respond with `structuredContent` AND the same JSON
+string in `content[0].text`. Search: `{results:[{id,title,url}]}`. Fetch:
+`{id,title,text,url,metadata?}`. `url` must be an absolute user-openable
+http(s) URL (or empty — internal IDs belong in `id`, never `url`).
+
+Mark every other read-only tool `annotations: { readOnlyHint: true }`.
+
+Enforcement: mcp-builder `validate` gains a `chatgpt_surface` check — for any
+service tagged ChatGPT-exposed, verify search/fetch presence, exact input
+schemas, and readOnlyHint coverage. The `/chatgpt/mcp` gateway (ChittyConnect)
+serves tool schemas from the ChittySchema canonical store (§3.6), not upstream
+self-reports.
+
 ## 4. The McpAgent wrap (canonical template)
 
 There is **no shared `McpAgent` base class** in `workers/shared/` — `agents/mcp`

--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -72,6 +72,18 @@ exactly once, where it belongs (the server name). A client connected directly
 to `<name>.chitty.cc/mcp` already knows which server it called, so bare names
 are still self-descriptive there.
 
+### Portal interop (CF MCP server portals — verified against CF docs 2026-07-13)
+- The portal surfaces tools/prompts as `{server_id}_{name}`, splitting on the
+  FIRST underscore — server IDs MUST use hyphens for multi-word names, never
+  underscores. Resources are not name-prefixed (the `<service>://` URI scheme
+  is the namespace).
+- `portal_` is reserved (portal-native tools) — never name a service `portal`.
+- JS-reserved verbs (`delete`) are safe: Code Mode sanitizes the NAMESPACED
+  name (`tasks_delete`), and since codemode v0.2.1 DynamicWorkerExecutor
+  sanitizes internally — do not hand-call `sanitizeToolName`.
+- Portal background-syncs upstream surfaces ~every 2h; allow for this when
+  verifying renames post-deploy.
+
 ### Verbs
 Canonical verbs (extend cautiously, document if new):
 `list, get, create, update, delete, claim, release, complete, fail, cancel,


### PR DESCRIPTION
## What

Three SOP amendments chartered 2026-07-13 (companion to chittyos/chittyentity#544):

- **§3.6 Baseline tools (binding)**: every service MCP must expose bare `status` and `describe` meta-tools, and POST its tool surface to ChittySchema (`schema.chitty.cc/api/tools/register`) on deploy. Gatekeeper treats an empty schema-registry entry as non-compliant. Implementation: `workers/shared/baseline-tools.ts` (chittyentity).
- **§3.7 ChatGPT surface conformance (binding for ChatGPT-exposed services)**: exact OpenAI-required `search` ({query}) / `fetch` ({id}) input signatures, structuredContent+content result shapes, citable `url` rules, `readOnlyHint` on read-only tools. Enforced by mcp-builder's `chatgpt_surface` validate check.
- **§3 portal-interop notes**: CF MCP portal splits namespaced names on the FIRST underscore (server IDs must be hyphenated, never underscored); `portal_` reserved; Code Mode sanitizes the namespaced name (codemode ≥v0.2.1 does it internally); ~2h portal background sync.

All verified against Cloudflare and OpenAI docs 2026-07-13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaaUAKcNZqBLH6A6pHFFRA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for interoperability between Cloudflare MCP server portals, including naming conventions and reserved namespaces.
  * Documented required baseline tools and schema registration for MCP services.
  * Added ChatGPT compatibility requirements for search and fetch tools, including schemas, responses, and read-only behavior.
  * Documented validation and schema-serving expectations for MCP integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->