### PR TITLE
governance: remove runtime KV membership authority (SERVICE_MAP is the compile-time projection)

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -4,18 +4,22 @@
 - **Tier**: 2 (Platform / Aggregator)
 - **Organization**: CHITTYOS
 - **Domain**: MCP Aggregation
-- **Role**: Universal MCP aggregator over all CF-gateway-registered service MCPs
+- **Role**: Universal MCP aggregator over the ChittyOS service MCPs (membership is a compile-time projection of ChittyRegistry)
 
 ## Mission
 
-ChittyMCP is the **universal MCP aggregator** for the ChittyOS ecosystem. Individual
-service MCPs are registered in the Cloudflare gateway as the source of truth; ChittyMCP
-federates them under a single canonical endpoint (`mcp.chitty.cc`) so any MCP client
-(Claude, ChatGPT, agents, IDEs) gets one URL and discovers the full surface.
+ChittyMCP is the **universal MCP aggregator** for the ChittyOS ecosystem. **ChittyRegistry
+(registry.chitty.cc) is the registry of record** for service membership; ChittyMCP's
+membership is a **compile-time generated projection** of that registry (`SERVICE_MAP` +
+`VIEW_CATEGORIES` + wrangler `services[]` bindings). ChittyMCP federates the services
+under a single canonical endpoint (`mcp.chitty.cc`) so any MCP client (Claude, ChatGPT,
+agents, IDEs) gets one URL and discovers the full surface.
 
 ## Aggregator Topology
 
-CF Gateway is the registry of record. Three aggregators consume it:
+**ChittyRegistry is the registry of record.** Three aggregators consume generated
+projections of it (the Cloudflare gateway performs edge auth/routing but is **not** the
+membership authority):
 
 | Aggregator | Endpoint | Surface | Audience | Auth |
 |------------|----------|---------|----------|------|
@@ -59,15 +63,15 @@ for the live binding list.
 ## Scope
 
 ### IS Responsible For
-- Federating CF-registered service MCPs under `mcp.chitty.cc`
+- Federating the projected service MCPs under `mcp.chitty.cc`
 - Routing `/{name}/mcp` requests to the bound service worker
-- Membership enforcement (tag + policy filter)
+- Membership enforcement (category filter over the compile-time `SERVICE_MAP` projection — no runtime membership read)
 - Exposing the official MCP `/v0.1/servers` discovery endpoint
 - Health / observability surface for the aggregator itself
 
 ### IS NOT Responsible For
 - Tool implementation (lives in each `chittyagent-*` service)
-- Service registration (CF gateway + ChittyRegistry)
+- Service registration (ChittyRegistry — the registry of record)
 - Identity / token issuance (ChittyID, ChittyAuth)
 - OAuth gating (that is ch1tty's job)
 - Persistent state for tool calls (each upstream owns its state)
@@ -76,8 +80,8 @@ for the live binding list.
 
 | Type | Service | Purpose |
 |------|---------|---------|
-| Source of truth | Cloudflare gateway | Service MCP registration |
-| Peer | ChittyRegistry | Canonical service catalog (`/v0.1/servers`) |
+| Registry of record | ChittyRegistry | Canonical service catalog; membership projected to `SERVICE_MAP` + wrangler bindings at build time |
+| Edge | Cloudflare Access / gateway | Per-service auth + routing (NOT the membership authority) |
 | Peer | chittymsg | Messaging-domain aggregator |
 | Peer | ch1tty | OAuth-protected smart gateway |
 | Upstream (bindings) | chittyagent-dispute, chittyagent-notes, chittyagent-ship, chittystorage, chittyrouter, chittycommand, chittyregistry, chittyconnect, chittyagent-ch1tty | Federated MCP backends |
@@ -90,7 +94,7 @@ Live binding set: see `wrangler.jsonc → services[]`.
 - [x] Single wrangler config (`wrangler.jsonc`)
 - [x] Tail consumer wired to `chittytrack`
 - [x] Routes `mcp.chitty.cc/*` to consolidated worker (`src/worker/index.ts`)
-- [ ] All upstream services declare tags at CF gateway registration
+- [ ] All upstream services registered in ChittyRegistry (membership projected into `SERVICE_MAP` + wrangler bindings)
 - [ ] `/v0.1/servers` discovery endpoint live
 - [ ] Per-aggregator policy filter implemented in `src/worker/`
 - [ ] Legacy directories (`mcp-evidence-server`, `mcp-unified-consolidated`, `chittyos-*-mcp`, `mcp-chittyconnect`, `mcp-handler.js`, etc.) removed or moved to `archive/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ lives in each `chittyagent-<name>` worker (separate repo:
 | `CHARTER.md`                  | Aggregator topology + scope                 |
 | `docs/MCP-SOP.md`             | **Canonical SOP for adding/wrapping any service MCP** |
 | `docs/ONBOARDING.md`          | Step-by-step add-to-aggregator procedure    |
-| `docs/agent-registry-triage.json` | Live triage of which services are deployed |
+| `docs/agent-registry-triage.json` | Generated triage snapshot of deployment status (NOT authoritative — ChittyRegistry is the registry of record) |
 | `wrangler.jsonc`              | Live service-binding list                   |
 | `src/worker/index.ts`         | The aggregator itself (353 LOC, data-driven)|
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,4 +17,4 @@ last_reviewed: "2026-05-26"
 - **Secrets Management:** All secrets flow through 1Password into the Cloudflare secrets store. Secrets are never hardcoded in the repository.
 
 ## Policy Enforcement
-Per-aggregator policy is enforced by reading tags from the Cloudflare gateway registration and mapped via `VIEW_CATEGORIES` in `src/worker/index.ts`.
+Per-aggregator policy is enforced at **compile time**: each service's `category` in `SERVICE_MAP` is mapped to a sub-view via `VIEW_CATEGORIES` in `src/worker/index.ts`. Both are **generated projections** of the ChittyRegistry manifest (the registry of record) — not a runtime read of Cloudflare gateway or KV state. There is no runtime membership store, so no request can be served against a stale or divergent service list.

--- a/docs/MCP-SOP.md
+++ b/docs/MCP-SOP.md
@@ -11,19 +11,28 @@
 ## 1. Topology (binding)
 
 ```
-   CF Gateway  ── registry of record (per-service registration + tags)
+   ChittyRegistry  ── registry of record (canonical service catalog)
         │
-        ├──► chittymcp   (mcp.chitty.cc)        — all services, machine surface
-        ├──► chittymsg   (msg.chitty.cc)        — domain:messaging only
-        └──► ch1tty      (ch1tty.chitty.cc)     — audience:human ∧ auth:oauth-ok
+        └─► generated manifest ──► compile-time projection into each aggregator
+              (SERVICE_MAP + VIEW_CATEGORIES + wrangler service bindings)
+                 │
+                 ├──► chittymcp   (mcp.chitty.cc)        — all services, machine surface
+                 ├──► chittymsg   (msg.chitty.cc)        — category:communication only
+                 └──► ch1tty      (ch1tty.chitty.cc)     — audience:human ∧ auth:oauth-ok
 ```
+
+> The Cloudflare gateway performs edge auth/routing; it is **not** the registry
+> of record. Aggregator membership is the compile-time projection above, not a
+> runtime read of gateway or KV state.
 
 - Service MCPs are **not** exposed directly to end clients. They are reached
   through one of the three aggregators (or future focused collections).
 - Per-service Cloudflare Access policies remain for ops/debugging, but client
   routing is always through an aggregator.
-- Adding a service to an aggregator is **never** a hand edit on the aggregator
-  side — it is a tag at registration time.
+- Adding a service to chittymcp is a **reviewed edit to the generated projection**
+  (`SERVICE_MAP` + wrangler `services[]`), landed via PR — the `/admin/bind` deploy
+  beacon opens exactly that PR. It is **never** a runtime mutation, and there is no
+  KV/posture fallback that could serve a divergent membership.
 
 ## 2. Required elements (every service MCP)
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -8,8 +8,9 @@ gate before the next.
 
 ```
        ┌────────────────────────────────────────────────────┐
-       │  Cloudflare gateway  (registry of record)          │
-       │  Each chittyagent-* registers its MCP + tags here  │
+       │  ChittyRegistry  (registry of record)              │
+       │  Canonical catalog → generated manifest → compile- │
+       │  time projection (SERVICE_MAP + wrangler bindings) │
        └────────────────────────────────────────────────────┘
                               │
         ┌─────────────────────┼─────────────────────┐
@@ -19,8 +20,11 @@ gate before the next.
                                               AND auth:oauth-ok)
 ```
 
-Aggregators read from the gateway by tag + policy. **You never edit aggregator
-configs to add a service** — you tag the service correctly and it shows up.
+Aggregator membership is a **compile-time projection** of ChittyRegistry into
+`SERVICE_MAP` + wrangler `services[]` bindings. You add a service by landing a
+**reviewed PR** that edits those projections — the `/admin/bind` deploy beacon
+opens exactly that PR automatically. It is never a runtime tag flip, and there
+is no KV/posture fallback that could serve a divergent membership.
 
 ## Step 1 — Build the service MCP
 
@@ -49,8 +53,9 @@ Register the service MCP through the gateway with the canonical tag set:
 | `auth` | yes | `service-binding`, `token`, `oauth-ok` |
 | `tier` | recommended | `0`–`5` per ChittyOS tier model |
 
-The gateway registration is the source of truth. ChittyRegistry mirrors it via
-`/v0.1/servers`.
+ChittyRegistry (registry.chitty.cc) is the registry of record; the aggregator
+surfaces a compile-time projection of it via `/v0.1/servers`. The gateway tags
+are edge auth/routing metadata, not the membership authority.
 
 **Gate:** `curl https://registry.chitty.cc/v0.1/servers | jq '.[] | select(.name=="<service>")'`
 returns your entry with tags.

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -55,14 +55,11 @@ interface Env {
   // Comma-separated allowlist of CF Access service-token client IDs permitted
   // to reach the MCP surface. Set via `wrangler secret put MCP_ALLOWED_ACCESS_CLIENT_IDS`.
   MCP_ALLOWED_ACCESS_CLIENT_IDS?: string;
-  MCP_REGISTRY?: KVNamespace;
   CLOUDFLARE_API_TOKEN?: string;
   CLOUDFLARE_ACCOUNT_ID?: string;
   CLOUDFLARE_ZONE_ID?: string;
   CHITTY_AUTH_SERVICE_TOKEN?: string;
   CHITTYAUTH_ISSUED_MCP_ADMIN_TOKEN?: string;
-  CHITTYREGISTER_POSTURE_URL?: string;
-  CHITTYAUTH_ISSUED_REGISTER_TOKEN?: string;
   // Cloudflare Access Application Audience tag for mcp.chitty.cc — when
   // present, JWT verification requires this aud claim. Optional but
   // recommended for production.
@@ -92,21 +89,23 @@ interface ServiceEntry {
   // /msg/mcp = communication). Reuses the `category` vocabulary from
   // ch1tty servers.json (finance, communication, platform, …) — NOT the
   // CHARTER's `domain:` tag, which was only ever documented, never enforced.
-  // Defaults to "platform" when a dynamic entry omits it.
+  // Set at compile time on every SERVICE_MAP entry (a generated projection of
+  // the ChittyRegistry manifest) — never read from a runtime store.
   category: string;
 }
 
-interface DynamicServiceEntry {
-  id: string;
-  sub: string;
-  binding: BindingKey;
-  label: string;
-  category?: string;
-  enabled?: boolean;
-  posture?: string;
-  trust_score?: number;
-}
-
+// Membership authority (governance correction, 2026-08): COMPILE-TIME ONLY.
+//
+//   ChittyRegistry (registry of record)
+//     → generated manifest
+//       → SERVICE_MAP + VIEW_CATEGORIES + wrangler.jsonc service bindings
+//
+// SERVICE_MAP, VIEW_CATEGORIES and the wrangler `services[]` bindings are
+// GENERATED PROJECTIONS of that manifest — not sources of truth themselves.
+// Membership changes ONLY by editing these projections in a reviewed PR (which
+// POST /admin/bind opens on a deploy beacon — see handleAdminBind). There is no
+// runtime KV/posture read: a request never learns the service list from a
+// mutable store, so it can never silently serve a stale or divergent membership.
 const SERVICE_MAP: Record<string, ServiceEntry> = {
   ai:               { binding: "SVC_AI",               label: "AI Gateway (chittyclaw)",            category: "platform" },
   alchemist:        { binding: "SVC_ALCHEMIST",        label: "Alchemist (telemetry + entity graph)", category: "platform" },
@@ -157,8 +156,6 @@ const VIEW_CATEGORIES: Record<string, string> = {
   msg: "communication",  // ChittyMsg — messaging/comms surface
 };
 
-const MCP_REGISTRY_KEY = "services:v1";
-
 // Allowlist of CF Access service-token client IDs permitted to reach the MCP
 // surface. CF Access service tokens are (client_id, secret) pairs; the secret
 // is 64 chars of unguessable cryptographic material. We trust a request whose
@@ -190,102 +187,15 @@ function requireAdmin(request: Request, env: Env): Response | null {
   return null;
 }
 
-function isEligibleByPosture(entry: DynamicServiceEntry): boolean {
-  if (entry.enabled === false) return false;
-  const posture = (entry.posture || "unknown").toLowerCase();
-  const trust = entry.trust_score ?? 0;
-  const postureAllowed = posture === "trusted" || posture === "verified" || posture === "certified";
-  return postureAllowed || trust >= 70;
-}
-
-async function loadActiveServices(env: Env): Promise<Record<string, ServiceEntry>> {
-  const fallback = SERVICE_MAP;
-  if (!env.MCP_REGISTRY) return fallback;
-
-  try {
-    const raw = await env.MCP_REGISTRY.get(MCP_REGISTRY_KEY);
-    if (!raw) return fallback;
-    const parsed = JSON.parse(raw) as DynamicServiceEntry[];
-    const active: Record<string, ServiceEntry> = {};
-    for (const entry of parsed) {
-      if (!entry?.id || !entry?.sub || !entry?.binding || !entry?.label) continue;
-      if (!isEligibleByPosture(entry)) continue;
-      active[entry.sub] = {
-        binding: entry.binding,
-        label: entry.label,
-        category: entry.category || SERVICE_MAP[entry.sub]?.category || "platform",
-      };
-    }
-    return Object.keys(active).length > 0 ? active : fallback;
-  } catch (err) {
-    console.error(`[ChittyMCP] Failed to load dynamic service map: ${err}`);
-    return fallback;
-  }
-}
-
-type PostureFetchResult =
-  | { status: "ok"; services: DynamicServiceEntry[] }
-  | { status: "not_configured" }
-  | { status: "fetch_failed"; error: string };
-
-async function fetchPostureRegistry(env: Env): Promise<PostureFetchResult> {
-  const url = env.CHITTYREGISTER_POSTURE_URL;
-  if (!url) return { status: "not_configured" };
-  const headers: Record<string, string> = { "content-type": "application/json" };
-  if (env.CHITTYAUTH_ISSUED_REGISTER_TOKEN) {
-    headers.authorization = `Bearer ${env.CHITTYAUTH_ISSUED_REGISTER_TOKEN}`;
-  }
-  let res: Response;
-  try {
-    res = await fetch(url, { method: "GET", headers });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[posture] fetch threw url=${url} err=${msg}`);
-    return { status: "fetch_failed", error: `network: ${msg}` };
-  }
-  if (!res.ok) {
-    console.error(`[posture] fetch non-2xx url=${url} status=${res.status}`);
-    return { status: "fetch_failed", error: `http ${res.status}` };
-  }
-  let payload: { services?: DynamicServiceEntry[] };
-  try {
-    payload = await res.json() as { services?: DynamicServiceEntry[] };
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[posture] non-JSON body url=${url} err=${msg}`);
-    return { status: "fetch_failed", error: `parse: ${msg}` };
-  }
-  if (!Array.isArray(payload.services)) {
-    return { status: "fetch_failed", error: "payload.services not an array" };
-  }
-  return { status: "ok", services: payload.services };
-}
-
-type SyncResult =
-  | { status: "synced"; count: number }
-  | { status: "no_kv" }
-  | { status: "fetch_failed"; error: string }
-  | { status: "empty" }
-  | { status: "kv_write_failed"; count: number; error: string };
-
-async function syncRegistryFromPosture(env: Env): Promise<SyncResult> {
-  if (!env.MCP_REGISTRY) return { status: "no_kv" };
-  const result = await fetchPostureRegistry(env);
-  if (result.status !== "ok") {
-    return result.status === "not_configured"
-      ? { status: "fetch_failed", error: "CHITTYREGISTER_POSTURE_URL not set" }
-      : { status: "fetch_failed", error: result.error };
-  }
-  if (result.services.length === 0) return { status: "empty" };
-  try {
-    await env.MCP_REGISTRY.put(MCP_REGISTRY_KEY, JSON.stringify(result.services));
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`[posture] KV write failed err=${msg}`);
-    return { status: "kv_write_failed", count: result.services.length, error: msg };
-  }
-  return { status: "synced", count: result.services.length };
-}
+// The former RUNTIME membership path — isEligibleByPosture / loadActiveServices /
+// fetchPostureRegistry / syncRegistryFromPosture, backed by an MCP_REGISTRY KV
+// namespace populated from CHITTYREGISTER_POSTURE_URL — has been REMOVED. It let
+// a runtime KV read override the reviewed, compile-time membership, and on any
+// miss (no KV, empty key, parse/fetch failure) it fell back SILENTLY to a stale
+// snapshot or the static map. Membership is now SERVICE_MAP only, with no
+// fallback path to diverge from (see the authority-chain note above SERVICE_MAP).
+// POST /admin/bind proposes membership changes as a reviewable PR, never a
+// runtime mutation (see handleAdminBind).
 
 class CfApiError extends Error {
   status: number;
@@ -959,7 +869,7 @@ function patchWorkerIndex(source: string, sub: string, bindingName: string, labe
   // Re-key the entry with proper "key:" form. The padEnd above gave us
   // "<sub>             " — append a colon at the right spot.
   // Simpler: rebuild the inserted line cleanly.
-  const cleanEntry = `  ${sub}: { binding: "${bindingName}", label: ${JSON.stringify(label)} },\n`;
+  const cleanEntry = `  ${sub}: { binding: "${bindingName}", label: ${JSON.stringify(label)}, category: "platform" },\n`;
   patched = patched.replace(entry, cleanEntry);
 
   return patched;
@@ -1417,8 +1327,10 @@ export default {
       }
     }
 
-    // Everything below depends on the active (posture-filtered) service map.
-    let serviceMap = await loadActiveServices(env);
+    // Everything below operates over the compile-time membership (SERVICE_MAP),
+    // the sole authority. Shallow-copy so the sub-view filter below can narrow
+    // it per request without mutating the module-level projection.
+    let serviceMap: Record<string, ServiceEntry> = { ...SERVICE_MAP };
 
     // Aggregate sub-view rewrite: a POST to /{view}/mcp (cpa, msg, …) narrows
     // the map to the services whose `category` matches that view, then rewrites
@@ -1456,7 +1368,7 @@ export default {
       if (deny) return deny;
       return Response.json({
         service: "chittymcp",
-        source: env.MCP_REGISTRY ? "dynamic-or-fallback" : "static",
+        source: "compile-time",
         services: Object.fromEntries(
           Object.entries(serviceMap).map(([id, s]) => [id, { path: `/${id}/mcp`, label: s.label }]),
         ),
@@ -1467,15 +1379,6 @@ export default {
     // so chittyagent-* workers can call it without holding admin credentials.
     if (request.method === "POST" && path === "/admin/bind") {
       return handleAdminBind(request, env);
-    }
-
-    if (request.method === "POST" && path === "/admin/registry/sync") {
-      const deny = requireAdmin(request, env);
-      if (deny) return deny;
-      const result = await syncRegistryFromPosture(env);
-      const ok = result.status === "synced";
-      const status = ok ? 200 : 502;
-      return Response.json({ ok, ...result }, { status });
     }
 
     if (request.method === "POST" && path === "/admin/reconcile/routes") {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,7 +19,12 @@
   //   mcp.chitty.cc/<name>/mcp       → proxied directly to chittyagent-<name>
   //   mcp.chitty.cc/v0.1/servers     → MCP-spec discovery
   //
-  // Source of truth for membership: docs/agent-registry-triage.json (Bucket A).
+  // Registry of record for membership: ChittyRegistry (registry.chitty.cc).
+  // These service bindings are a GENERATED PROJECTION of the ChittyRegistry
+  // manifest — not a source of truth themselves. docs/agent-registry-triage.json
+  // is a generated triage snapshot, likewise not authoritative. Membership
+  // changes land here only via a reviewed PR (POST /admin/bind opens exactly
+  // that PR on a deploy beacon — never a runtime mutation).
   // Services not yet deployed (Bucket C) are intentionally NOT bound — re-add when live.
   "services": [
     { "binding": "SVC_AI",           "service": "chittyagent-ai" },


### PR DESCRIPTION
## Membership authority correction

Removes the runtime KV/posture membership authority from the ChittyMCP aggregator and makes **compile-time** membership the sole authority, matching documented governance.

### Authority flow (before → after)

**Before:** each request called `loadActiveServices(env)`, which read the `MCP_REGISTRY` KV namespace (populated from `CHITTYREGISTER_POSTURE_URL` via `syncRegistryFromPosture`), filtered by posture/trust, and **silently fell back** to the static map on any miss. A runtime KV write could override the reviewed membership.

**After:**

```
ChittyRegistry (registry of record)
  → generated manifest
    → SERVICE_MAP + VIEW_CATEGORIES + wrangler.jsonc service bindings   (generated projections)
```

Every request operates over `SERVICE_MAP` (a shallow copy for per-request sub-view narrowing). No runtime store is consulted; there is no fallback path that could diverge.

### Removed vs. replaced

**Removed (runtime membership authority):**
- `MCP_REGISTRY` KV binding + `MCP_REGISTRY_KEY`
- `loadActiveServices()` (KV read + silent fallback)
- `syncRegistryFromPosture()` and `fetchPostureRegistry()` (posture→KV write)
- `isEligibleByPosture()`, `DynamicServiceEntry`, `PostureFetchResult`, `SyncResult`
- `POST /admin/registry/sync` route (the posture→KV mutation endpoint)
- Env fields `CHITTYREGISTER_POSTURE_URL`, `CHITTYAUTH_ISSUED_REGISTER_TOKEN`

**Replaced with (compile-time projection):**
- `let serviceMap = { ...SERVICE_MAP }` in the fetch handler — `SERVICE_MAP` + `VIEW_CATEGORIES` + wrangler `services[]` bindings are the membership.
- `/registry/services` `source` is now `"compile-time"`.
- `/admin/bind` is preserved **as a PR generator only** (`handleAdminBind` opens a branch + PR against `SERVICE_MAP`/wrangler on a deploy beacon; it never mutates runtime state). Generated `SERVICE_MAP` entries now include `category` so the PR it opens is type-clean.

Net: `src/worker/index.ts` −97 LOC.

### Acceptance criteria

- [x] **1. No runtime KV membership authority remains** — `MCP_REGISTRY`, its KV read path, and the posture sync are deleted; no `env.MCP_REGISTRY` reference exists.
- [x] **2. No silent fallback to stale membership** — the `loadActiveServices` KV-miss→fallback and posture→KV paths are gone; membership is `SERVICE_MAP` only, with no alternate source to diverge from.
- [x] **3. SERVICE_MAP / VIEW_CATEGORIES / wrangler bindings are treated as generated projections** — documented in code (authority-chain comment above `SERVICE_MAP`) and in CHARTER/SECURITY/MCP-SOP/ONBOARDING/wrangler as projections of the ChittyRegistry manifest, not sources of truth.
- [x] **4. `/admin/bind` only opens a reviewable PR** — `handleAdminBind` opens a GitHub PR against the manifest/`SERVICE_MAP`/wrangler; it performs no runtime membership mutation.
- [x] **5. Docs no longer name the CF gateway, KV, or triage JSON as the registry of record** — CHARTER.md, SECURITY.md, docs/MCP-SOP.md, docs/ONBOARDING.md, CLAUDE.md, and the wrangler.jsonc comment updated to name **ChittyRegistry** as the registry of record and the projections as generated.
- [x] **6. Typecheck + tests pass** — see results below.
- [x] **7. MCP Inspector result reported separately** — see below.
- [x] **8. No merge, no deploy** — this PR is left open; nothing deployed.

### Validation results

**Typecheck (`tsc --noEmit`):** the refactor introduces **zero new type errors**. The tree has 16 pre-existing baseline errors — all `Cannot find name 'env'` in the `discover*`/`forward*` helpers (their signatures omit `env`); identical set before and after this change, only line numbers shifted. Left untouched as out-of-scope pre-existing bugs (flagged for follow-up).

**Real build (`wrangler deploy --dry-run`, esbuild — the actual ship path):** ✅ bundles cleanly.

**Tests (`node --test test/governance-gates.test.js`):** ✅ 16/16 pass.

**MCP Inspector smoke** (`@modelcontextprotocol/inspector --cli` against local `wrangler dev` `/mcp`, `tools/list`): ✅ **PASS** — Inspector completed the `initialize` handshake and returned `{"tools": []}`. The empty list reflects the 38 upstream service bindings being `[not connected]` in local dev, not a defect in the aggregator.

### Note for review
- Generated auto-bind SERVICE_MAP entries default to `category: "platform"`; adjust to the correct category when the PR the beacon opens is reviewed.
- The pre-existing `env`-in-`discover*` type errors are unrelated to this change and were intentionally not touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Service membership is now managed through reviewed configuration updates rather than runtime registration.
  * Registry reporting now reflects the authoritative service catalog and generated projections.
  * Service categories are required, including a default platform category for automatic bindings.
  * Edge authentication and routing remain supported, while membership authority is clarified.
  * Removed runtime registry synchronization and related administrative endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->